### PR TITLE
Fix touch input

### DIFF
--- a/SignallingWebServer/scripts/app.js
+++ b/SignallingWebServer/scripts/app.js
@@ -2017,6 +2017,8 @@ function registerTouchEvents(playerElement) {
 
     function forgetTouch(touch) {
         fingers.push(fingerIds[touch.identifier]);
+        // Sort array back into descending order. This means if finger '1' were to lift after finger '0', we would ensure that 0 will be the first index to pop
+        fingers.sort(function(a, b){return b - a});
         delete fingerIds[touch.identifier];
     }
 


### PR DESCRIPTION
This commit fixes an issue where finger indexs are handled incorrectly.

eg If Finger 1 where to lift after Finger 0, the next finger to touch the screen will be given the index 1 even though it should be given the index 0.