### PR TITLE
Bug fix to retrieve the correct selected ice candidate pair

### DIFF
--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -323,7 +323,7 @@ export class AggregatedStats {
         // Check if the RTCTransport stat is not undefined
         if (this.transportStats){
             // Return the candidate pair that matches the transport candidate pair id
-            return this.candidatePairs.find((candidatePair) => candidatePair.id = this.transportStats.selectedCandidatePairId, null);
+            return this.candidatePairs.find((candidatePair) => candidatePair.id === this.transportStats.selectedCandidatePairId, null);
         }
         
         // Fall back to the selected candidate pair

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -33,6 +33,7 @@ export class AggregatedStats {
     sessionStats: SessionStats;
     streamStats: StreamStats;
     codecs: Map<string, string>;
+    transport: RTCTransportStats;
 
     constructor() {
         this.inboundVideoStats = new InboundVideoStats();
@@ -94,6 +95,7 @@ export class AggregatedStats {
                     this.handleTrack(stat);
                     break;
                 case 'transport':
+                    this.handleTransport(stat);
                     break;
                 case 'stream':
                     this.handleStream(stat);
@@ -267,6 +269,11 @@ export class AggregatedStats {
         }
     }
 
+    handleTransport(stat: RTCTransportStats){
+        this.transport = stat;
+    }
+
+
     handleCodec(stat: CodecStats) {
         const codecId = stat.id;
         const codecType = `${stat.mimeType
@@ -312,6 +319,14 @@ export class AggregatedStats {
      * @returns The candidate pair that is currently receiving data
      */
     public getActiveCandidatePair(): CandidatePairStats | null {
-        return this.candidatePairs.find((candidatePair) => candidatePair.bytesReceived > 0, null)
+        
+        // Check if the RTCTransport stat is not undefined
+        if (this.transport){
+            // Return the candidate pair that matches the transport candidate pair id
+            return this.candidatePairs.find((candidatePair) => candidatePair.id = this.transport.selectedCandidatePairId, null);
+        }
+        
+        // Fall back to the selected candidate pair
+        return this.candidatePairs.find((candidatePair) => candidatePair.selected, null);
     }  
 }

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -33,7 +33,7 @@ export class AggregatedStats {
     sessionStats: SessionStats;
     streamStats: StreamStats;
     codecs: Map<string, string>;
-    transport: RTCTransportStats;
+    transportStats: RTCTransportStats;
 
     constructor() {
         this.inboundVideoStats = new InboundVideoStats();
@@ -270,7 +270,7 @@ export class AggregatedStats {
     }
 
     handleTransport(stat: RTCTransportStats){
-        this.transport = stat;
+        this.transportStats = stat;
     }
 
 
@@ -321,9 +321,9 @@ export class AggregatedStats {
     public getActiveCandidatePair(): CandidatePairStats | null {
         
         // Check if the RTCTransport stat is not undefined
-        if (this.transport){
+        if (this.transportStats){
             // Return the candidate pair that matches the transport candidate pair id
-            return this.candidatePairs.find((candidatePair) => candidatePair.id = this.transport.selectedCandidatePairId, null);
+            return this.candidatePairs.find((candidatePair) => candidatePair.id = this.transportStats.selectedCandidatePairId, null);
         }
         
         // Fall back to the selected candidate pair


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The active candidate pair returned from the `AggregatedStats.getActiveCandidatePair` function is returning the 1st candidate pair element which has received any bytes, some browsers will receive data on multiple candidate pairs which is not the selected candidate pair

## Solution
Implement the handling of the [`RTCTransportStats`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats) from the [`RTCStatsReport`](https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport)

Retrieve the selected candidate pair from the list of candidate pairs using the [`selectedcandidatepairid`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats#selectedcandidatepairid) from the [`RTCTransportStats`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats)

Due to [`browser_compatibility`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats#browser_compatibility) fire fox doesn't support [`RTCTransportStats`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats) 

In the case of the [`RTCTransportStats`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats) being undefined  fall back to use the [`selected`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/selected) property of the [`RTCIceCandidatePairStats`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats)