### PR TITLE
Add flag to enable flex-fec support

### DIFF
--- a/Frontend/Docs/Settings Panel.md
+++ b/Frontend/Docs/Settings Panel.md
@@ -23,6 +23,8 @@ This page will be updated with new features and commands as they become availabl
 | **Force mono audio** | Force the browser to request mono audio in the SDP. |
 | **Force TURN** | Will attempt to connect exclusively via the TURN server. Will not work without an active TURN server. |
 | **Suppress browser keys** | Suppress or allow certain keys we use in UE, for example F5 to show shader complexity instead of refreshing the page. |
+| **Wait for streamer** | Will continue trying to connect until a streamer becomes available, at which point it will automatically subscribe to it. |
+| **Use FlexFec** | Will signal to WebRTC to enable Flexible Forward Error Correction |
 | **AFK if Idle** | Timeout the connection if no input is detected for a period of time. |
 | **AFK timeout** | Allows you to specify the AFK timeout period. |
 | **Max Reconnects** | The maximum number of reconnects the application will attempt when a streamer disconnects. |

--- a/Frontend/library/package-lock.json
+++ b/Frontend/library/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4",
-            "version": "0.0.3",
+            "version": "0.0.5",
             "license": "MIT",
             "dependencies": {
                 "sdp": "^3.1.0"

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -32,6 +32,7 @@ export class Flags {
     static GamepadInput = 'GamepadInput' as const;
     static XRControllerInput = 'XRControllerInput' as const;
     static WaitForStreamer = "WaitForStreamer" as const;
+    static UseFlexFec = "UseFlexFec" as const;
 }
 
 export type FlagsKeys = Exclude<keyof typeof Flags, 'prototype'>;
@@ -497,6 +498,19 @@ export class Config {
                 settings && settings.hasOwnProperty(Flags.WaitForStreamer) ?
                     settings[Flags.WaitForStreamer] :
                     true,
+                useUrlParams
+            )
+        );
+
+        this.flags.set(
+            Flags.UseFlexFec,
+            new SettingFlag(
+                Flags.UseFlexFec,
+                'Use FlexFec',
+                'Will signal to WebRTC to enable Flexible Forward Error Correction',
+                settings && settings.hasOwnProperty(Flags.UseFlexFec) ?
+                    settings[Flags.UseFlexFec] :
+                    false,
                 useUrlParams
             )
         );

--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -407,6 +407,26 @@ export class PeerConnectionController {
                             });
                         });
 
+                    // If the user has toggle the "UseFlexFec" flag, we want to add it to the top of the codec preferences list.
+                    // We don't want it as a selectable codec because the first "actual" codec in the list is the codec that will be
+                    // protected.
+                    if(this.config.isFlagEnabled(Flags.UseFlexFec)) {
+                        const matcher = /(flexfec).*/;
+                        RTCRtpReceiver.getCapabilities('video').codecs.forEach((codec) => {
+                            const str = codec.mimeType.split('/')[1] + ' ' + (codec.sdpFmtpLine || '');
+                            const match = matcher.exec(str);
+                            if (match !== null) {
+                                codecs.push({
+                                    mimeType: codec.mimeType,
+                                    clockRate: codec.clockRate,
+                                    sdpFmtpLine: codec.sdpFmtpLine
+                                        ? codec.sdpFmtpLine
+                                        : ''
+                                });
+                            }
+                        });
+                    }
+
                     for (const codec of codecs) {
                         if (codec.sdpFmtpLine === '') {
                             // We can't dynamically add members to the codec, so instead remove the field if it's empty

--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -407,7 +407,7 @@ export class PeerConnectionController {
                             });
                         });
 
-                    // If the user has toggle the "UseFlexFec" flag, we want to add it to the top of the codec preferences list.
+                    // If the user has toggle the "UseFlexFec" flag, we want to add it to the top of the preferences list.
                     // We don't want it as a selectable codec because the first "actual" codec in the list is the codec that will be
                     // protected.
                     if(this.config.isFlagEnabled(Flags.UseFlexFec)) {

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -198,6 +198,10 @@ export class ConfigUI {
             psSettingsSection,
             this.flagsUi.get(Flags.WaitForStreamer)
         );
+        this.addSettingFlag(
+            psSettingsSection,
+            this.flagsUi.get(Flags.UseFlexFec)
+        );
         this.addSettingNumeric(
             psSettingsSection,
             this.numericParametersUi.get(NumericParameters.AFKTimeoutSecs)

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -192,15 +192,15 @@ export class ConfigUI {
         );
         this.addSettingFlag(
             psSettingsSection,
-            this.flagsUi.get(Flags.AFKDetection)
-        );
-        this.addSettingFlag(
-            psSettingsSection,
             this.flagsUi.get(Flags.WaitForStreamer)
         );
         this.addSettingFlag(
             psSettingsSection,
             this.flagsUi.get(Flags.UseFlexFec)
+        );
+        this.addSettingFlag(
+            psSettingsSection,
+            this.flagsUi.get(Flags.AFKDetection)
         );
         this.addSettingNumeric(
             psSettingsSection,


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
WebRTC has supported receiving Flexible Forward Error Corrected (FlexFec) streams as default since M92. With PixelStreaming recently adding support for this feature, it makes sense for the frontend to support it as well.

## Solution
This PR adds a new flag (and corresponding UI toggle) for enabling FlexFec support. With the toggle enabled, the browser will signal its support for FlexFec to the Unreal Engine application. If the application also supports FlexFec, the video stream will be protected.

## Documentation
Updated `Settings Panel.md` to contain information about the new toggle.

## Test Plan and Compatibility
Tested connecting to streams with the toggle both enabled and disabled. If the application supports FlexFec and the toggle is enabled, additional information regarding the FEC packets can be seen in Chrome's webrtc-internals.