### PR TITLE
Added SDP for probator

### DIFF
--- a/Frontend/library/src/VideoPlayer/StreamController.ts
+++ b/Frontend/library/src/VideoPlayer/StreamController.ts
@@ -31,7 +31,8 @@ export class StreamController {
             'handleOnTrack ' + JSON.stringify(rtcTrackEvent.streams),
             6
         );
-        
+        // Do not add the track if the ID is `probator` as this is special track created by mediasoup for bitrate probing.
+        // Refer to https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/86 for more details.
         if (rtcTrackEvent.track.id == 'probator') {
             return;
         }

--- a/Frontend/library/src/VideoPlayer/StreamController.ts
+++ b/Frontend/library/src/VideoPlayer/StreamController.ts
@@ -31,6 +31,11 @@ export class StreamController {
             'handleOnTrack ' + JSON.stringify(rtcTrackEvent.streams),
             6
         );
+        
+        if (rtcTrackEvent.track.id == 'probator') {
+            return;
+        }
+
         const videoElement = this.videoElementProvider.getVideoElement();
 
         if (rtcTrackEvent.track) {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [x] SFU

## Problem statement:
The current SFU does not always select the appropriate resolution stream even when simulcast is configured.
This may be because mediasoup is sending a stream for inspection under the name "probator", but it is not receiving this stream properly, so the inspection is not performed properly and the bitrate estimation is not done properly.

## Solution
Fixes #85 

![simul](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/assets/1144427/9fcde09e-ca54-4def-887d-3dc203d5bf4f)