### PR TITLE
fix:kicked player should not try to reconnect

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -220,9 +220,11 @@ export class WebRtcPlayerController {
             // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
             // lists all the codes. 
             const CODE_GOING_AWAY = 1001;
+            const CODE_KICK = 3000;
 
             const willTryReconnect = this.shouldReconnect
                && event.detail.code != CODE_GOING_AWAY
+               && event.detail.code != CODE_KICK
                && this.config.getNumericSettingValue(NumericParameters.MaxReconnectAttempts) > 0
 
             const disconnectMessage = this.disconnectMessage ? this.disconnectMessage : event.detail.reason;

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -590,7 +590,7 @@ function onStreamerMessageDisconnectPlayer(streamer, msg) {
 	const playerId = getPlayerIdFromMessage(msg);
 	const player = players.get(playerId);
 	if (player) {
-		player.ws.close(1011 /* internal error */, msg.reason);
+		player.ws.close(3000 /* kick */, msg.reason);
 	}
 }
 


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
kicked player still tries to reconnect

## Solution
1. change Signalling server to send code 3000 when player get kicked
2. change Frontend library websocket on close,if code is 3000 then don't reconnect


