### PR TITLE
Adding an option to hide the UI.

### DIFF
--- a/Frontend/library/package-lock.json
+++ b/Frontend/library/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4",
-            "version": "0.0.3",
+            "version": "0.0.5",
             "license": "MIT",
             "dependencies": {
                 "sdp": "^3.1.0"

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -31,7 +31,8 @@ export class Flags {
     static TouchInput = 'TouchInput' as const;
     static GamepadInput = 'GamepadInput' as const;
     static XRControllerInput = 'XRControllerInput' as const;
-    static WaitForStreamer = "WaitForStreamer" as const;
+    static WaitForStreamer = 'WaitForStreamer' as const;
+    static HideUI = 'HideUI' as const;
 }
 
 export type FlagsKeys = Exclude<keyof typeof Flags, 'prototype'>;
@@ -497,6 +498,19 @@ export class Config {
                 settings && settings.hasOwnProperty(Flags.WaitForStreamer) ?
                     settings[Flags.WaitForStreamer] :
                     true,
+                useUrlParams
+            )
+        );
+        
+        this.flags.set(
+            Flags.HideUI,
+            new SettingFlag(
+                Flags.HideUI,
+                'Hide the UI overlay',
+                'Will hide all UI overlay details',
+                settings && settings.hasOwnProperty(Flags.HideUI) ?
+                    settings[Flags.HideUI] :
+                    false,
                 useUrlParams
             )
         );

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -138,6 +138,17 @@ export class Application {
         this.showConnectOrAutoConnectOverlays();
 
         this.setColorMode(this.configUI.isCustomFlagEnabled(LightMode));
+
+        this.stream.config._addOnSettingChangedListener(
+            Flags.HideUI,
+            (isEnabled: boolean) => {
+                this._uiFeatureElement.style.visibility = isEnabled ? "hidden" : "visible";
+            }
+        );
+
+        if (this.stream.config.isFlagEnabled(Flags.HideUI)) {
+            this._uiFeatureElement.style.visibility = "hidden";
+        }
     }
 
     public createOverlays(): void {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Sometimes it would be nice to hide the UI on the frontend.

## Solution
Added a config option `HideUI=true` to hide the UI on the frontend.

## Documentation

## Test Plan and Compatibility
