### PR TITLE
Replaces first and last double quote sanitization which are added to the default launch arguments for http_root affecting startup

### DIFF
--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -97,6 +97,9 @@ if (!cli_options.no_config) {
 // merge the configurations
 const options: IProgramOptions = { ...config_file, ...cli_options };
 
+// sanitize starting and ending double quotes on http_root in options from default arguments
+options.http_root = options.http_root.replace(/^"(.*)"$/, '$1');
+
 // save out new configuration (unless disabled)
 if (!options.no_save) {
 


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
What problem does this PR address?
Without this fix, the current start server procedure won't resolve to the proper path of `player.html`. The server will report back with `Unable to locate file player.html`

## Solution
How does this PR solve the problem?
In `index.ts` we sanitize the merged program options using a replace regex to strip the leading and trailing double quotes from `http_root` if they exist.

## Screenshots
Current `master` error:
![image](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/assets/5181711/bb5b89d1-3633-45ab-ae4d-319629d70c2b)
