### PR TITLE
Fixes relating to batch scripts, frontend paths and peer connection options.

### DIFF
--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -151,7 +151,11 @@ export class SignallingServer {
         this.streamerRegistry.add(newStreamer);
         newStreamer.transport.on('close', () => { this.streamerRegistry.remove(newStreamer); });
 
-        newStreamer.sendMessage(MessageHelpers.createMessage(Messages.config, this.protocolConfig));
+        // because peer connection options is a general field with all optional fields
+        // it doesnt play nice with mergePartial so we just add it verbatim
+        let message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
+        newStreamer.sendMessage(message);
     }
 
     private onPlayerConnected(ws: WebSocket, request: http.IncomingMessage) {
@@ -172,7 +176,11 @@ export class SignallingServer {
         this.playerRegistry.add(newPlayer);
         newPlayer.transport.on('close', () => { this.playerRegistry.remove(newPlayer); });
 
-        newPlayer.sendMessage(MessageHelpers.createMessage(Messages.config, this.protocolConfig));
+        // because peer connection options is a general field with all optional fields
+        // it doesnt play nice with mergePartial so we just add it verbatim
+        let message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
+        newPlayer.sendMessage(message);
     }
 
     private onSFUConnected(ws: WebSocket, request: http.IncomingMessage) {
@@ -187,6 +195,10 @@ export class SignallingServer {
             this.playerRegistry.remove(newSFU);
         });
 
-        newSFU.sendMessage(MessageHelpers.createMessage(Messages.config, this.protocolConfig));
+        // because peer connection options is a general field with all optional fields
+        // it doesnt play nice with mergePartial so we just add it verbatim
+        let message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
+        newSFU.sendMessage(message);
     }
 }

--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -153,7 +153,7 @@ export class SignallingServer {
 
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
-        const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        const message: Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newStreamer.sendMessage(message);
@@ -179,7 +179,7 @@ export class SignallingServer {
 
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
-        const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        const message: Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newPlayer.sendMessage(message);
@@ -199,7 +199,7 @@ export class SignallingServer {
 
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
-        const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        const message: Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newSFU.sendMessage(message);

--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -154,6 +154,7 @@ export class SignallingServer {
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
         const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newStreamer.sendMessage(message);
     }
@@ -179,6 +180,7 @@ export class SignallingServer {
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
         const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newPlayer.sendMessage(message);
     }
@@ -198,6 +200,7 @@ export class SignallingServer {
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
         const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newSFU.sendMessage(message);
     }

--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -153,7 +153,7 @@ export class SignallingServer {
 
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
-        let message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newStreamer.sendMessage(message);
     }
@@ -178,7 +178,7 @@ export class SignallingServer {
 
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
-        let message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newPlayer.sendMessage(message);
     }
@@ -197,7 +197,7 @@ export class SignallingServer {
 
         // because peer connection options is a general field with all optional fields
         // it doesnt play nice with mergePartial so we just add it verbatim
-        let message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
+        const message:Messages.config = MessageHelpers.createMessage(Messages.config, this.protocolConfig);
         message.peerConnectionOptions = this.protocolConfig.peerConnectionOptions;
         newSFU.sendMessage(message);
     }

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -92,7 +92,7 @@ IF NOT "%1"=="" (
     )
     IF "%1"=="--frontend-dir" (
         set HANDLED=1
-        set FRONTEND_DIR=%2
+        set FRONTEND_DIR=%~2
         SHIFT
     )
     IF NOT "!HANDLED!"=="1" (
@@ -141,7 +141,7 @@ IF "%FRONTEND_DIR%"=="" (
 )
 
 rem try to make it an absolute path
-call :NormalizePath %FRONTEND_DIR%
+call :NormalizePath "%FRONTEND_DIR%"
 set FRONTEND_DIR=%RETVAL%
 
 rem Set this for webpack

--- a/SignallingWebServer/platform_scripts/cmd/start.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start.bat
@@ -16,19 +16,19 @@ IF "%CONTINUE%"=="1" (
 	set SERVER_ARGS=!SERVER_ARGS! --serve --console_messages verbose --https_redirect --public_ip=!PUBLIC_IP!
 	IF NOT "!STUN_SERVER!"=="" (
 		IF NOT "!TURN_SERVER!"=="" (
-			set PEER_OPTIONS={\\\"iceServers\\\":[{\\\"urls\\\":[\\\"stun:!STUN_SERVER!\\\",\\\"turn:!TURN_SERVER!\\\"],\\\"username\\\":\\\"!TURN_USER!\\\",\\\"credential\\\":\\\"!TURN_PASS!\\\"}]}
+			set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"stun:!STUN_SERVER!\",\"turn:!TURN_SERVER!\"],\"username\":\"!TURN_USER!\",\"credential\":\"!TURN_PASS!\"}]}
 		) ELSE (
-			set PEER_OPTIONS={\\\"iceServers\\\":[{\\\"urls\\\":[\\\"stun:!STUN_SERVER!\\\"]}]}
+			set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"stun:!STUN_SERVER!\"]}]}
 		)
 	) ELSE IF NOT "!TURN_SERVER!"=="" (
-		set PEER_OPTIONS={\\\"iceServers\\\":[{\\\"urls\\\":[\\\"turn:!TURN_SERVER!\\\"],\\\"username\\\":\\\"!TURN_USER!\\\",\\\"credentials\\\":\\\"!TURN_PASS!\\\"}]}
+		set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"turn:!TURN_SERVER!\"],\"username\":\"!TURN_USER!\",\"credentials\":\"!TURN_PASS!\"}]}
 	)
 
 	IF NOT "!PEER_OPTIONS!"=="" (
-		set SERVER_ARGS=!SERVER_ARGS! --peer_options=\"!PEER_OPTIONS!\"
+		set SERVER_ARGS=!SERVER_ARGS! --peer_options="!PEER_OPTIONS!"
 	)
 	IF NOT "!FRONTEND_DIR!"=="" (
-		set SERVER_ARGS=!SERVER_ARGS! --http_root=\"!FRONTEND_DIR!\"
+		set SERVER_ARGS=!SERVER_ARGS! --http_root="!FRONTEND_DIR!"
 	)
 	
 	call :PrintConfig


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
On windows the frontend path was not being passed to the signalling server properly leading to stray quotes in the path.
Additionally the peer connection options were not properly being passed to connecting peers.

## Solution
The batch scripts have been updated to properly handle paths with spaces and not end up with excess quotation marks.
The peer connection option string has also been altered to properly pass them to the signalling server.
The signalling server has been updated to add the peer connection options properly to the config message.

## Documentation

## Test Plan and Compatibility

Closes #113 