### PR TITLE
Fix: path normalizing on Windows

### DIFF
--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -141,7 +141,7 @@ IF "%FRONTEND_DIR%"=="" (
 )
 
 rem try to make it an absolute path
-call :NormalizePath "%FRONTEND_DIR%"
+call :NormalizePath %FRONTEND_DIR%
 set FRONTEND_DIR=%RETVAL%
 
 rem Set this for webpack


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [X] Platform scripts
- [ ] SFU

## Problem statement:
Path normalizing is broken in the Windows platform scripts.

![image](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/assets/29305253/8e91d027-754c-47de-9474-552b96205387)

## Solution
Removed superfluous quotes