### PR TITLE
Fixed platform scripts on Windows looking in wrong frontend dir, sensitive to spaces in paths, and not setting user PATH to contain NodeJS.

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -334,7 +334,7 @@ function start_process() {
     if [[ "${NO_SUDO}" == 1 ]]; then
         eval $(echo "$@" | sed 's/sudo//g')
     else
-        eval $@
+        eval "$@"
     fi
 }
 
@@ -357,7 +357,7 @@ function start_wilbur() {
     echo "Starting wilbur signalling server use ctrl-c to exit"
     echo "----------------------------------"
     
-    start_process "sudo PATH=$PATH ${NPM} start -- ${SERVER_ARGS}"
+    start_process "sudo PATH=\"$PATH\" ${NPM} start -- ${SERVER_ARGS}"
 
     popd > /dev/null
 }

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -157,7 +157,7 @@ for /f "tokens=2*" %%A in ('reg query "HKCU\Environment" /v PATH ^| find "PATH"'
 rem Store user's PATH in OLD_PATH
 set OLD_PATH=%USER_PATH%
 rem Update this processes PATH to have node dir (this WILL NOT persist outside this process which is a problem for NPM run scripts we use)
-set PATH="%NODE_DIR%;%PATH%"
+set PATH=%NODE_DIR%;%PATH%
 set PATH_LENGTH=0
 for %%A in ("%NODE_DIR%;%OLD_PATH%") do set "PATH_LENGTH=%%~zA"
 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -132,60 +132,85 @@ rem NOTE: We want to use our NodeJS (not system NodeJS!) to build the web fronte
 rem Save our current directory (the NodeJS dir) in a variable
 set NODE_DIR=%SCRIPT_DIR%node
 
-rem Prepend NODE_DIR to PATH temporarily
-set "OLDPATH=%PATH%"
-set "PATH=%PATH%;%NODE_DIR%"
-
 IF "%FRONTEND_DIR%"=="" (
     set FRONTEND_DIR="%SCRIPT_DIR%..\..\www"
+) else (
+    set FRONTEND_DIR="%FRONTEND_DIR%"
 )
 
 rem try to make it an absolute path
-call :NormalizePath "%FRONTEND_DIR%"
+call :NormalizePath %FRONTEND_DIR%
 set FRONTEND_DIR=%RETVAL%
 
 rem Set this for webpack
 set WEBPACK_OUTPUT_PATH=%FRONTEND_DIR%
 
-IF NOT exist %FRONTEND_DIR%\player.html (
+IF NOT exist "%FRONTEND_DIR%\player.html" (
     set FORCE_BUILD=1
+)
+
+rem Query the registry to get the value of the PATH variable for the current user (We DO NOT want the system PATH - %PATH% combines user and system PATH.)
+for /f "tokens=2*" %%A in ('reg query "HKCU\Environment" /v PATH ^| find "PATH"') do (
+    set "USER_PATH=%%B"
+)
+
+rem Store OLD_PATH NODE_PATH
+set OLD_PATH=%USER_PATH%
+rem Update this processes PATH to have node dir (this WILL NOT persist outside this process which is a problem for NPM run scripts we use)
+set PATH=%PATH%%NODE_DIR%
+set PATH_LENGTH=0
+for %%A in ("!OLD_PATH!") do set "PATH_LENGTH=%%~zA"
+
+IF !PATH_LENGTH! GTR 1024 (
+    echo "Your PATH is greater than 1024 characters, cmd setx cannot change it. Either shorten your user's PATH contents or hope you have NodeJS in your PATH already..."
+) else (
+    rem Set new user PATH for all processes
+    setx PATH "%OLD_PATH%%NODE_DIR%"
+    set PATH_NEEDS_RESTORE=1
 )
 
 IF "%FORCE_BUILD%"=="1" (
     rem We could replace this all with a single npm script that does all this. we do have several build-all scripts already
     rem but this does give a good reference about the dependency chain for all of this.
     rem Note: npm link will also run npm install so we dont need that here
+    echo Testing common library...
+    pushd %CD%\Common
+    call "%SCRIPT_DIR%node\npm" run compile
+    popd
     echo Building common library...
     echo ----------------------------
     pushd %CD%\Common
-    call %SCRIPT_DIR%\node\npm install
-    call %SCRIPT_DIR%\node\npm run build
+    call "%SCRIPT_DIR%node\npm" install
+    call "%SCRIPT_DIR%node\npm" run build
     popd
     echo Building frontend library...
     echo ----------------------------
     pushd %CD%\Frontend\library
-    call %SCRIPT_DIR%\node\npm link ../../Common
-    call %SCRIPT_DIR%\node\npm run build
+    call "%SCRIPT_DIR%node\npm" link ../../Common
+    call "%SCRIPT_DIR%node\npm" run build
     popd
     echo Building frontend-ui library...
     echo ----------------------------
     pushd %CD%\Frontend\ui-library
-    call %SCRIPT_DIR%\node\npm link ../library
-    call %SCRIPT_DIR%\node\npm run build
+    call "%SCRIPT_DIR%node\npm" link ../library
+    call "%SCRIPT_DIR%node\npm" run build
     popd
     echo Building Epic Games reference frontend...
     echo ----------------------------
     pushd %CD%\Frontend\implementations\typescript
-    call %SCRIPT_DIR%\node\npm link ../../library ../../ui-library
-    call %SCRIPT_DIR%\node\npm run build
+    call "%SCRIPT_DIR%node\npm" link ../../library ../../ui-library
+    call "%SCRIPT_DIR%node\npm" run build
     popd
     popd
 ) else (
     echo Skipping rebuilding frontend... %FRONTEND_DIR% has content already, use --build to force a frontend rebuild.
 )
 
-rem Restore path
-set "PATH=%OLDPATH%"
+IF "%PATH_NEEDS_RESTORE%"=="1" (
+    rem Restore PATH
+    setx PATH "%OLD_PATH%"
+)
+
 exit /b
 
 :SetupCoturn
@@ -271,13 +296,13 @@ pushd %SCRIPT_DIR%\..\..\
 echo Building signalling library...
 echo ----------------------------
 pushd ..\Signalling
-call %SCRIPT_DIR%\node\npm link ../Common
-call %SCRIPT_DIR%\node\npm run build
+call "%SCRIPT_DIR%node\npm" link ../Common
+call "%SCRIPT_DIR%node\npm" run build
 popd
 echo Building wilbur...
 echo ----------------------------
-call %SCRIPT_DIR%\node\npm link ../Signalling
-call %SCRIPT_DIR%\node\npm run build
+call "%SCRIPT_DIR%node\npm" link ../Signalling
+call "%SCRIPT_DIR%node\npm" run build
 call %NPM% run start -- %SERVER_ARGS%
 exit /b
 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -157,7 +157,7 @@ for /f "tokens=2*" %%A in ('reg query "HKCU\Environment" /v PATH ^| find "PATH"'
 rem Store user's PATH in OLD_PATH
 set OLD_PATH=%USER_PATH%
 rem Update this processes PATH to have node dir (this WILL NOT persist outside this process which is a problem for NPM run scripts we use)
-set PATH=%PATH%%NODE_DIR%
+set PATH="%NODE_DIR%;%PATH%"
 set PATH_LENGTH=0
 for %%A in ("%NODE_DIR%;%OLD_PATH%") do set "PATH_LENGTH=%%~zA"
 
@@ -173,10 +173,6 @@ IF "%FORCE_BUILD%"=="1" (
     rem We could replace this all with a single npm script that does all this. we do have several build-all scripts already
     rem but this does give a good reference about the dependency chain for all of this.
     rem Note: npm link will also run npm install so we dont need that here
-    echo Testing common library...
-    pushd %CD%\Common
-    call "%SCRIPT_DIR%node\npm" run compile
-    popd
     echo Building common library...
     echo ----------------------------
     pushd %CD%\Common

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -154,18 +154,18 @@ for /f "tokens=2*" %%A in ('reg query "HKCU\Environment" /v PATH ^| find "PATH"'
     set "USER_PATH=%%B"
 )
 
-rem Store OLD_PATH NODE_PATH
+rem Store user's PATH in OLD_PATH
 set OLD_PATH=%USER_PATH%
 rem Update this processes PATH to have node dir (this WILL NOT persist outside this process which is a problem for NPM run scripts we use)
 set PATH=%PATH%%NODE_DIR%
 set PATH_LENGTH=0
-for %%A in ("%OLD_PATH%%NODE_DIR%") do set "PATH_LENGTH=%%~zA"
+for %%A in ("%NODE_DIR%;%OLD_PATH%") do set "PATH_LENGTH=%%~zA"
 
 IF !PATH_LENGTH! GTR 1024 (
     echo "Your PATH is greater than 1024 characters, cmd setx cannot change it. Either shorten your user's PATH contents or hope you have NodeJS in your PATH already..."
 ) else (
     rem Set new user PATH for all processes
-    setx PATH "%OLD_PATH%%NODE_DIR%"
+    setx PATH "%NODE_DIR%;%OLD_PATH%"
     set PATH_NEEDS_RESTORE=1
 )
 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -159,7 +159,7 @@ set OLD_PATH=%USER_PATH%
 rem Update this processes PATH to have node dir (this WILL NOT persist outside this process which is a problem for NPM run scripts we use)
 set PATH=%PATH%%NODE_DIR%
 set PATH_LENGTH=0
-for %%A in ("!OLD_PATH!") do set "PATH_LENGTH=%%~zA"
+for %%A in ("%OLD_PATH%%NODE_DIR%") do set "PATH_LENGTH=%%~zA"
 
 IF !PATH_LENGTH! GTR 1024 (
     echo "Your PATH is greater than 1024 characters, cmd setx cannot change it. Either shorten your user's PATH contents or hope you have NodeJS in your PATH already..."

--- a/SignallingWebServer/platform_scripts/cmd/start.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start.bat
@@ -45,4 +45,4 @@ goto :eof
 :SetupTurnStun
 :PrintConfig
 :StartWilbur
-%~dp0common.bat %*
+"%~dp0common.bat" %*

--- a/SignallingWebServer/platform_scripts/cmd/start_turn.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start_turn.bat
@@ -23,4 +23,4 @@ goto :eof
 :SetupTurnStun
 :PrintConfig
 :StartWilbur
-%~dp0common.bat %*
+"%~dp0common.bat" %*

--- a/SignallingWebServer/platform_scripts/cmd/start_with_stun.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start_with_stun.bat
@@ -2,4 +2,4 @@
 @echo off
 setlocal enabledelayedexpansion
 
-call %~dp0start.bat --default-stun %*
+call "%~dp0start.bat" --default-stun %*

--- a/SignallingWebServer/platform_scripts/cmd/start_with_turn.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start_with_turn.bat
@@ -2,4 +2,4 @@
 @echo off
 setlocal enabledelayedexpansion
 
-call %~dp0start.bat --default-stun --default-turn --start-turn %*
+call "%~dp0start.bat" --default-stun --default-turn --start-turn %*


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
What problem does this PR address?

A few problems were identified:

1. The frontend directory which the Windows platform scripts would try to create/look for was unable to create a normalized path from combining two paths together.
2. A number of the `call` sites in the Windows platforms scripts were sensitive to directories which had a space in them.
3. When NodeJS did not exist on the system or user PATH, the platform scripts would fail as they only set NodeJS on the process PATH.
4. Powershell was being used in some cases, PowerShell is not guaranteed to be callable on a fresh install of non-pro versions of Windows without user intervention.

## Solution
How does this PR solve the problem?

Each of the issues was resolved as follows:

1. The frontend path was combined together by using/not using quotes in certain places to escape paths with spaces in them.
2. A number of the `call` functions in the scripts needed to be escaped with quotes.
3. The user PATH is now retrieved, and it is updated to include the NodeJS path. This is undone after the scripts have built everything. HOWEVER, the caveat to this change is Windows batch can only set the user PATH using `setx` - setx has a 1024 character limit. Therefore if the user PATH exceeds 1024 characters the script will emit a warning saying it will not set the path and the user can either trim their PATH or manually install NodeJS into the PATH.
4. Powershell calls were removed and replaced with windows batch equivalents.

## Documentation
If you added a new feature or changed an existing feature please add some documentation here.

No docs changes

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compataibility with the existing functionality? 

- Test the platforms scripts on Windows with NodeJS not present on the system.
- Also tested using a path with a space in it. 
- Tested `start.bat --frontend-dir=D:\Pixel Streaming Infrastructure\SignallingWebServer\www` (note the spaces).
- Test all `start_*.bat` files with space in path
