### PR TITLE
Updating platform scripts to skip build when not needed.

### DIFF
--- a/Common/.dockerignore
+++ b/Common/.dockerignore
@@ -1,0 +1,3 @@
+build/
+node_modules/
+

--- a/Signalling/.dockerignore
+++ b/Signalling/.dockerignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/SignallingWebServer/.dockerignore
+++ b/SignallingWebServer/.dockerignore
@@ -1,0 +1,3 @@
+build/
+node_modules/
+

--- a/SignallingWebServer/Dockerfile
+++ b/SignallingWebServer/Dockerfile
@@ -6,6 +6,7 @@ COPY /Signalling /Signalling
 COPY /SignallingWebServer /SignallingWebServer
 COPY /Frontend /Frontend
 # Install the dependencies for the signalling server and build the frontend
+RUN apt-get update
 RUN SignallingWebServer/platform_scripts/bash/setup.sh --build
 
 # Expose TCP ports 80 and 443 for player WebSocket connections and web server HTTP(S) access

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -120,7 +120,7 @@ function check_and_install() { #dep_name #get_version_string #version_min #insta
 		check_version "$current" "$minimum"
 		if [ "$?" -lt 2 ]; then
 			echo "$1 is installed."
-			return 0
+            is_installed=1
 		else
 			echo "Required install of $1 not found installing"
 		fi
@@ -132,10 +132,8 @@ function check_and_install() { #dep_name #get_version_string #version_min #insta
 		start_process $4
 
 		if [ $? -ge 1 ]; then
-			echo "Installation of $1 failed try running `export VERBOSE=1` then run this script again for more details"
-            return -1
+			echo "Installation of $1 failed try running 'export VERBOSE=1' then run this script again for more details"
 		fi
-        return 1
 	fi
 }
 
@@ -180,11 +178,9 @@ function setup_node() {
                                                                 && rm node.tar.xz
                                                                 && mv node-v*-*-* \"${SCRIPT_DIR}/node\""
 
-    # only run install if needed
-    if [[ $? == 1 ]]; then
-        PATH="${SCRIPT_DIR}/node/bin:$PATH"
-        "${SCRIPT_DIR}/node/lib/node_modules/npm/bin/npm-cli.js" install
-    fi
+    PATH="${SCRIPT_DIR}/node/bin:$PATH"
+    "${SCRIPT_DIR}/node/lib/node_modules/npm/bin/npm-cli.js" install
+
     popd > /dev/null
 }
 

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -24,6 +24,7 @@ function print_usage() {
                             Default value as above
         --build             Force a rebuild of the typescript frontend even if it already exists
         --frontend-dir      Sets the output path for the fontend build
+        --dev               Dev mode. (forces build of wilbur and its dependencies)
 
     Other options: stored and passed to the server.  All parameters printed once the script values are set.
     Command line options might be omitted to run with defaults and it is a good practice to omit specific ones when just starting the TURN or the STUN server alone, not the whole set of scripts.
@@ -38,6 +39,7 @@ function parse_args() {
     FORCE_BUILD=0
     DEFAULT_STUN=0
     DEFAULT_TURN=0
+    BUILD_WILBUR=0
     while(($#)) ; do
         case "$1" in
         --debug ) IS_DEBUG=1; shift;;
@@ -53,6 +55,7 @@ function parse_args() {
         --start-turn ) START_TURN=1; shift;;
         --publicip ) PUBLIC_IP="$2"; shift 2;;
         --frontend-dir ) FRONTEND_DIR="$(realpath "$2")"; shift 2;;
+        --dev ) BUILD_WILBUR=1; shift;;
         --help ) print_usage;;
         * ) SERVER_ARGS+=" $1"; shift;;
         esac
@@ -130,7 +133,9 @@ function check_and_install() { #dep_name #get_version_string #version_min #insta
 
 		if [ $? -ge 1 ]; then
 			echo "Installation of $1 failed try running `export VERBOSE=1` then run this script again for more details"
+            return -1
 		fi
+        return 1
 	fi
 }
 
@@ -175,9 +180,11 @@ function setup_node() {
                                                                 && rm node.tar.xz
                                                                 && mv node-v*-*-* \"${SCRIPT_DIR}/node\""
 
-    PATH="${SCRIPT_DIR}/node/bin:$PATH"
-    "${SCRIPT_DIR}/node/lib/node_modules/npm/bin/npm-cli.js" install
-
+    # only run install if needed
+    if [[ $? == 1 ]]; then
+        PATH="${SCRIPT_DIR}/node/bin:$PATH"
+        "${SCRIPT_DIR}/node/lib/node_modules/npm/bin/npm-cli.js" install
+    fi
     popd > /dev/null
 }
 
@@ -341,18 +348,36 @@ function start_process() {
 # Assumes the following are set
 # SCRIPT_DIR = The path to the root of the PixelStreamingInfrastructure repo.
 # NPM = The npm command path
-# SERVER_ARGS The arguments to be passed to the server
-function start_wilbur() {
+function build_wilbur() {
     pushd ${SCRIPT_DIR}/../../.. > /dev/null
 
+    pushd Common > /dev/null
+    if [[ ! -d "build" ]]; then
+        echo Building common
+        ${NPM} run build
+    fi
+    popd
+
     pushd Signalling > /dev/null
+    echo Building signalling
     ${NPM} link ../Common
     ${NPM} run build
     popd > /dev/null
 
     pushd SignallingWebServer > /dev/null
+    echo Building wilbur
     ${NPM} link ../Signalling
     ${NPM} run build
+
+    popd > /dev/null
+}
+
+# Assumes the following are set
+# SCRIPT_DIR = The path to the root of the PixelStreamingInfrastructure repo.
+# NPM = The npm command path
+# SERVER_ARGS The arguments to be passed to the server
+function start_wilbur() {
+    pushd ${SCRIPT_DIR}/../../../SignallingWebServer > /dev/null
 
     echo "Starting wilbur signalling server use ctrl-c to exit"
     echo "----------------------------------"
@@ -361,4 +386,3 @@ function start_wilbur() {
 
     popd > /dev/null
 }
-

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -40,6 +40,9 @@ function parse_args() {
     DEFAULT_STUN=0
     DEFAULT_TURN=0
     BUILD_WILBUR=0
+    if [[ ! -d "${SCRIPT_DIR}/../../build/" ]]; then
+        BUILD_WILBUR=1
+    fi
     while(($#)) ; do
         case "$1" in
         --debug ) IS_DEBUG=1; shift;;

--- a/SignallingWebServer/platform_scripts/bash/start.sh
+++ b/SignallingWebServer/platform_scripts/bash/start.sh
@@ -24,6 +24,10 @@ if [[ ! -z "$FRONTEND_DIR" ]]; then
     SERVER_ARGS+=" --http_root=\"$FRONTEND_DIR\""
 fi
 
+if [[ ! -d "build/" ]]; then
+    BUILD_WILBUR=1
+fi
+
 if [[ "$BUILD_WILBUR" == "1" ]]; then
     build_wilbur
 fi

--- a/SignallingWebServer/platform_scripts/bash/start.sh
+++ b/SignallingWebServer/platform_scripts/bash/start.sh
@@ -24,10 +24,6 @@ if [[ ! -z "$FRONTEND_DIR" ]]; then
     SERVER_ARGS+=" --http_root=\"$FRONTEND_DIR\""
 fi
 
-if [[ ! -d "build/" ]]; then
-    BUILD_WILBUR=1
-fi
-
 if [[ "$BUILD_WILBUR" == "1" ]]; then
     build_wilbur
 fi

--- a/SignallingWebServer/platform_scripts/bash/start.sh
+++ b/SignallingWebServer/platform_scripts/bash/start.sh
@@ -24,6 +24,10 @@ if [[ ! -z "$FRONTEND_DIR" ]]; then
     SERVER_ARGS+=" --http_root=\"$FRONTEND_DIR\""
 fi
 
+if [[ "$BUILD_WILBUR" == "1" ]]; then
+    build_wilbur
+fi
+
 print_config
 start_wilbur
 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -300,6 +300,13 @@ exit /b
 
 :BuildWilbur
 pushd %SCRIPT_DIR%\..\..\
+pushd ..\Common
+IF NOT EXIST build\ (
+    echo Building common library...
+    echo ------------------------
+    call "%SCRIPT_DIR%node\npm" run build
+)
+popd
 echo Building signalling library...
 echo ----------------------------
 pushd ..\Signalling

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -28,11 +28,13 @@ echo        --stun ^<stun_ip^>        STUN server to be used
 echo        --default-stun          Uses IP address downloaded from https://api.ipify.org and sets up default stun parameters
 echo        --build                 Force a rebuild of the typescript frontend even if it already exists
 echo        --frontend-dir ^<path^>   Sets the output path for the fontend build
+echo        --dev                   Dev mode (forces build of wilbur and its dependencies)
 echo    Other options: stored and passed to the server.
 set CONTINUE=0
 exit /b
 
 :ParseArgs
+set BUILD_WILBUR=0
 set FORCE_BUILD=0
 set DEFAULT_STUN=0
 set DEFAULT_TURN=0
@@ -44,6 +46,9 @@ set TURN_USER=
 set TURN_PASS=
 set STUN_SERVER=
 set PUBLIC_IP=
+if not exist build\ (
+    set BUILD_WILBUR=1
+)
 :arg_loop
 IF NOT "%1"=="" (
     set HANDLED=0
@@ -95,6 +100,9 @@ IF NOT "%1"=="" (
         set FRONTEND_DIR=%~2
         SHIFT
     )
+    IF "%1"=="--dev" (
+        set BUILD_WILBUR=1
+    )
     IF NOT "!HANDLED!"=="1" (
         set SERVER_ARGS=%SERVER_ARGS% %1
     )
@@ -120,7 +128,8 @@ if exist node\ (
 )
 
 rem Print node version
-echo Node version: & node\node.exe -v
+FOR /f %%A IN ('node\node.exe -v') DO set NODE_VERSION=%%A
+echo Node version: %NODE_VERSION%
 popd
 exit /b
 
@@ -165,7 +174,7 @@ IF !PATH_LENGTH! GTR 1024 (
     echo "Your PATH is greater than 1024 characters, cmd setx cannot change it. Either shorten your user's PATH contents or hope you have NodeJS in your PATH already..."
 ) else (
     rem Set new user PATH for all processes
-    setx PATH "%NODE_DIR%;%OLD_PATH%"
+    setx PATH "%NODE_DIR%;%OLD_PATH%" >NUL
     set PATH_NEEDS_RESTORE=1
 )
 
@@ -204,7 +213,7 @@ IF "%FORCE_BUILD%"=="1" (
 
 IF "%PATH_NEEDS_RESTORE%"=="1" (
     rem Restore PATH
-    setx PATH "%OLD_PATH%"
+    setx PATH "%OLD_PATH%" >NUL
 )
 
 exit /b
@@ -237,7 +246,7 @@ call :SetupCoturn
 exit /b
 
 :SetPublicIP
-FOR /f %%A IN ('curl http://api.ipify.org') DO set PUBLIC_IP=%%A
+FOR /f %%A IN ('curl --silent http://api.ipify.org') DO set PUBLIC_IP=%%A
 Echo External IP is : %PUBLIC_IP%
 exit /b
 
@@ -289,7 +298,7 @@ echo Server command line arguments: %SERVER_ARGS%
 echo.
 exit /b
 
-:StartWilbur
+:BuildWilbur
 pushd %SCRIPT_DIR%\..\..\
 echo Building signalling library...
 echo ----------------------------
@@ -301,6 +310,11 @@ echo Building wilbur...
 echo ----------------------------
 call "%SCRIPT_DIR%node\npm" link ../Signalling
 call "%SCRIPT_DIR%node\npm" run build
+popd
+exit /b
+
+:StartWilbur
+pushd %SCRIPT_DIR%\..\..\
 call %NPM% run start -- %SERVER_ARGS%
 exit /b
 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -46,7 +46,7 @@ set TURN_USER=
 set TURN_PASS=
 set STUN_SERVER=
 set PUBLIC_IP=
-if not exist build\ (
+if not exist "%SCRIPT_DIR%\..\..\build\" (
     set BUILD_WILBUR=1
 )
 :arg_loop

--- a/SignallingWebServer/platform_scripts/cmd/start.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start.bat
@@ -31,18 +31,24 @@ IF "%CONTINUE%"=="1" (
 		set SERVER_ARGS=!SERVER_ARGS! --http_root="!FRONTEND_DIR!"
 	)
 	
-	call :PrintConfig
+    if "%BUILD_WILBUR%"=="1" (
+        call :BuildWilbur
+    )
+    
+    call :PrintConfig
 	call :StartWilbur
 	pause
 )
 
 goto :eof
 
+REM These labels will all jump to common.bat but also jump to the label inside common.bat
 :Init
 :ParseArgs
 :Setup
 :SetPublicIP
 :SetupTurnStun
 :PrintConfig
+:BuildWilbur
 :StartWilbur
 "%~dp0common.bat" %*


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
Startup time too long.

## Solution
Skip build if don't need.
