### PR TITLE
Fixing SFU probator stream exclusion. This will fix using SFU with Firefox

### DIFF
--- a/Frontend/library/src/VideoPlayer/StreamController.ts
+++ b/Frontend/library/src/VideoPlayer/StreamController.ts
@@ -33,7 +33,7 @@ export class StreamController {
         );
         // Do not add the track if the ID is `probator` as this is special track created by mediasoup for bitrate probing.
         // Refer to https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/86 for more details.
-        if (rtcTrackEvent.track.id == 'probator') {
+        if (rtcTrackEvent.streams.length < 1 || rtcTrackEvent.streams[0].id == 'probator') {
             return;
         }
 


### PR DESCRIPTION

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When using an SFU the stream never shows on Firefox.

## Solution
We were deliberately excluding a track called 'probator' that is added by mediasoup but on firefox the track id was not set and instead the stream id was set to probator. This change just changes where we look for the id.
