### PR TITLE
Script tweaks

### DIFF
--- a/SignallingWebServer/package.json
+++ b/SignallingWebServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epicgames-ps/wilbur",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A basic signalling server application for Unreal Engine's Pixel Streaming applications.",
   "main": "index.js",
   "scripts": {

--- a/SignallingWebServer/package.json
+++ b/SignallingWebServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epicgames-ps/wilbur",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "description": "A basic signalling server application for Unreal Engine's Pixel Streaming applications.",
   "main": "index.js",
   "scripts": {

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -319,7 +319,6 @@ function setup_turn_stun() {
     TURN_REALM="PixelStreaming"
     TURN_ARGUMENTS="-c turnserver.conf --allowed-peer-ip=$LOCAL_IP -p ${TURN_PORT} -r ${TURN_REALM} -X ${PUBLIC_IP} -E ${LOCAL_IP} --no-cli --no-tls --no-dtls --pidfile /var/run/turnserver.pid -f -a -v -u ${TURN_USER}:${TURN_PASS}"
 
-    echo TURN_ARGUMENTS=$TURN_ARGUMENTS
     if [[ "$1" == "bg" ]]; then
         TURN_ARGUMENTS+=" >/dev/null &"
     fi

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -107,7 +107,6 @@ function check_version() { #current_version #min_version
 
 function check_and_install() { #dep_name #get_version_string #version_min #install_command
 	local is_installed=0
-    NODE_WAS_INSTALLED=0
 
 	echo "Checking for required $1 install"
 
@@ -137,8 +136,6 @@ function check_and_install() { #dep_name #get_version_string #version_min #insta
 
 		if [ $? -ge 1 ]; then
 			echo "Installation of $1 failed try running 'export VERBOSE=1' then run this script again for more details"
-        else
-            NODE_WAS_INSTALLED=1
 		fi
 	fi
 }

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -385,7 +385,6 @@ function start_wilbur() {
     echo "Starting wilbur signalling server use ctrl-c to exit"
     echo "----------------------------------"
     
-    echo sudo PATH=\"$PATH\" ${NPM} start -- ${SERVER_ARGS}
     start_process "sudo PATH=\"$PATH\" ${NPM} start -- ${SERVER_ARGS}"
 
     popd > /dev/null


### PR DESCRIPTION
npm wont stomp your links by running install every time the start script is run.
PUBLIC_IP wont get stomped if you set it manually.
TURN wont mess up console logging and silently run in the background (if enabled).
