### PR TITLE
Adding handling for the layerPreference signalling message.

### DIFF
--- a/Signalling/src/PlayerConnection.ts
+++ b/Signalling/src/PlayerConnection.ts
@@ -106,6 +106,7 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
         this.protocol.on(Messages.iceCandidate.typeName, this.sendToStreamer.bind(this));
         this.protocol.on(Messages.dataChannelRequest.typeName, this.sendToStreamer.bind(this));
         this.protocol.on(Messages.peerDataChannelsReady.typeName, this.sendToStreamer.bind(this));
+        this.protocol.on(Messages.layerPreference.typeName, this.sendToStreamer.bind(this));
     }
 
     private sendToStreamer(message: BaseMessage): void {


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The layerPreference signalling message was not handled.

## Solution
Added a simple hook to handle the layerPreference message by forwarding it on to the SFU.
