### PR TITLE
Frontend - Provide default values to avoid potential NAN value returned when using dynamic player aspect ratios

### DIFF
--- a/Frontend/library/src/Util/CoordinateConverter.ts
+++ b/Frontend/library/src/Util/CoordinateConverter.ts
@@ -92,11 +92,12 @@ export class CoordinateConverter {
         this.videoElement = this.videoElementProvider.getVideoElement();
 
         if (this.videoElementParent && this.videoElement) {
-            const playerAspectRatio =
-                this.videoElementParent.clientHeight /
-                this.videoElementParent.clientWidth;
-            const videoAspectRatio =
-                this.videoElement.videoHeight / this.videoElement.videoWidth;
+            const playerWidth = this.videoElementParent.clientWidth || 1;
+            const playerHeight = this.videoElementParent.clientHeight || 1;
+            const videoWidth = this.videoElement.videoWidth || 1;
+            const videoHeight = this.videoElement.videoHeight || 1;
+            const playerAspectRatio = playerHeight / playerWidth;
+            const videoAspectRatio = videoHeight / videoWidth;
             if (playerAspectRatio > videoAspectRatio) {
                 Logger.Log(
                     Logger.GetStackTrace(),


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
What problem does this PR address?
Our app uses various UI layouts for different pages and the pixel streaming player resizes to fit the available space as needed.  Currently there is an issue in the where the value of the X mouse coord in CoordinateConverter.tsx can return NAN.  I have found this to happen when the stream first starts and when the player hasn't yet resized and therefore could be zero, however resizing the player to zero width could also cause similar issues.

## Solution
How does this PR solve the problem?
The PR provides temporary default values that are divisible and prevents NAN from being returned.

## Documentation
If you added a new feature or changed an existing feature please add some documentation here.

Or better yet, link to the relevant `/Docs` update in your PR.

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compatibility with the existing functionality? 
I have printed the returning value to the screen from every possible combination of layouts I have available.

Or better yet, link to the unit tests that accompany this PR.
