### PR TITLE
Send XREyeViews if available

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -709,6 +709,15 @@ export class WebRtcPlayerController {
         );
         this.streamMessageController.registerMessageHandler(
             MessageDirection.ToStreamer,
+            'XREyeViews',
+            (data: Array<number | string>) =>
+                this.sendMessageController.sendMessageToStreamer(
+                    'XREyeViews',
+                    data
+                )
+        );
+        this.streamMessageController.registerMessageHandler(
+            MessageDirection.ToStreamer,
             'XRHMDTransform',
             (data: Array<number | string>) =>
                 this.sendMessageController.sendMessageToStreamer(

--- a/Frontend/library/src/WebXR/WebXRController.ts
+++ b/Frontend/library/src/WebXR/WebXRController.ts
@@ -173,6 +173,34 @@ export class WebXRController {
                 mat[3], mat[7], mat[11], mat[15]
             ]);
 
+            if (pose.views.length >= 2) {
+                const leftEyeIndex = pose.views[0].eye === "left" ? 0 : 1;
+                const rightEyeIndex = 1 - leftEyeIndex;
+                const leftEyeMatrix = pose.views[leftEyeIndex].transform.matrix;
+                const leftEyeViewport = pose.views[leftEyeIndex].projectionMatrix;
+                const rightEyeMatrix = pose.views[rightEyeIndex].transform.matrix;
+                const rightEyeViewport = pose.views[rightEyeIndex].projectionMatrix;
+
+                this.webRtcController.streamMessageController.toStreamerHandlers.get('XREyeViews')([
+                    leftEyeMatrix[0], leftEyeMatrix[4], leftEyeMatrix[8], leftEyeMatrix[12],
+                    leftEyeMatrix[1], leftEyeMatrix[5], leftEyeMatrix[9], leftEyeMatrix[13],
+                    leftEyeMatrix[2], leftEyeMatrix[6], leftEyeMatrix[10], leftEyeMatrix[14],
+                    leftEyeMatrix[3], leftEyeMatrix[7], leftEyeMatrix[11], leftEyeMatrix[15],
+                    leftEyeViewport[0], leftEyeViewport[4], leftEyeViewport[8], leftEyeViewport[12],
+                    leftEyeViewport[1], leftEyeViewport[5], leftEyeViewport[9], leftEyeViewport[13],
+                    leftEyeViewport[2], leftEyeViewport[6], leftEyeViewport[10], leftEyeViewport[14],
+                    leftEyeViewport[3], leftEyeViewport[7], leftEyeViewport[11], leftEyeViewport[15],
+                    rightEyeMatrix[0], rightEyeMatrix[4], rightEyeMatrix[8], rightEyeMatrix[12],
+                    rightEyeMatrix[1], rightEyeMatrix[5], rightEyeMatrix[9], rightEyeMatrix[13],
+                    rightEyeMatrix[2], rightEyeMatrix[6], rightEyeMatrix[10], rightEyeMatrix[14],
+                    rightEyeMatrix[3], rightEyeMatrix[7], rightEyeMatrix[11], rightEyeMatrix[15],
+                    rightEyeViewport[0], rightEyeViewport[4], rightEyeViewport[8], rightEyeViewport[12],
+                    rightEyeViewport[1], rightEyeViewport[5], rightEyeViewport[9], rightEyeViewport[13],
+                    rightEyeViewport[2], rightEyeViewport[6], rightEyeViewport[10], rightEyeViewport[14],
+                    rightEyeViewport[3], rightEyeViewport[7], rightEyeViewport[11], rightEyeViewport[15],
+                ]);
+            }
+
             const glLayer = this.xrSession.renderState.baseLayer;
             // If we do have a valid pose, bind the WebGL layer's framebuffer,
             // which is where any content to be displayed on the XRDevice must be


### PR DESCRIPTION
## Relevant components:
- [X] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
What problem does this PR address?
Transform + Viewport should be auto-detected via WebXR #7 

## Solution
How does this PR solve the problem?
It adds the missing counter part to [UE 5.4.2 feature](https://github.com/EpicGames/UnrealEngine/commit/e32e1c540b728bd8185c73ed4765d2319fa4e1ba)

## Documentation
XREyeView is additionally send in Frontend/library/src/WebXR/WebXRController.ts `onXrFrame`.

## Test Plan and Compatibility
Standalone build and tested with Quest 3 device.
