### PR TITLE
Make XR changes compatible with UE 5.4.2

### DIFF
--- a/Frontend/library/package.json
+++ b/Frontend/library/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.4",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Frontend library for Unreal Engine 5.4 Pixel Streaming",
     "main": "dist/lib-pixelstreamingfrontend.js",
     "module": "dist/lib-pixelstreamingfrontend.esm.js",

--- a/Frontend/library/src/Inputs/XRGamepadController.ts
+++ b/Frontend/library/src/Inputs/XRGamepadController.ts
@@ -113,7 +113,7 @@ export class XRGamepadController {
                 if (currButton.pressed) {
                     // press
                     let isRepeat = prevButton.pressed ? 1 : 0;
-                    this.toStreamerMessagesProvider.toStreamerHandlers.get('XRButtonPressed')([handedness, i, isRepeat, currButton.value]);
+                    this.toStreamerMessagesProvider.toStreamerHandlers.get('XRButtonPressed')([handedness, i, isRepeat]);
                 } else if (prevButton.pressed) {
                     this.toStreamerMessagesProvider.toStreamerHandlers.get('XRButtonReleased')([handedness, i, 0]);
                 }


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The `UE5.4` branch of the PSInfra had completely broken its compatibility with UE 5.4.2 XR hotfix - https://github.com/EpicGames/UnrealEngine/commit/e32e1c540b728bd8185c73ed4765d2319fa4e1ba

## Solution
This PR ensures the XR data being sent by the frontend matches what UE 5.4.2 expects. The previous changes had introduced extra fields into the `XREyeViews` and `XRButtonPressed` messages. These extra fields would cause the message validation to fail.

## Documentation
- It should be noted while this restores the functionality from crashing/not sending data, the streaming experience is far from production ready. The streaming experience in the MQ2 is undistorted/correctly projected, but in the MQ3 and AVP the perspective is strongly warped when moving your head up and down. This is fixed in https://github.com/EpicGames/UnrealEngine/commit/08e45355e45516993c2db887cdd5b72fa20aa805 (UE side change) however this fix also requires changes on the frontend side (e.g. this fix https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/177).

## Test Plan and Compatibility
Test with UE 5.4.2 and MQ 2 and 3. As mentioned MQ3 streams, but perspective warps (which is expected).
