### PR TITLE
Addressing websocket close codes and reasons.

### DIFF
--- a/Common/src/Transport/WebSocketTransport.ts
+++ b/Common/src/Transport/WebSocketTransport.ts
@@ -178,11 +178,4 @@ export class WebSocketTransport extends EventEmitter implements ITransport {
         );
         this.emit('close', event);
     }
-
-    /**
-     * Closes the Websocket connection
-     */
-    close(): void {
-        this.webSocket?.close();
-    }
 }

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1674,7 +1674,7 @@ export class WebRtcPlayerController {
         this.locallyClosed = true;
         this.shouldReconnect = false;
         this.disconnectMessage = message;
-        this.protocol?.disconnect();
+        this.protocol?.disconnect(1000, message);
     }
 
     /**


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Some instances of the websocket close could be described better with a code and or reasons.

## Solution
Added explicit close code and reasons to one location.

Closes #17
