### PR TITLE
The URL parameters should now be case insensitive in the frontend.

### DIFF
--- a/Frontend/library/src/Config/SettingBase.ts
+++ b/Frontend/library/src/Config/SettingBase.ts
@@ -6,6 +6,8 @@
 export class SettingBase {
     id: string;
     description: string;
+    useUrlParams: boolean;
+    _urlParams: Record<string, string>;
     _label: string;
     _value: unknown;
     onChange: (changedValue: unknown, setting: SettingBase) => void;
@@ -19,6 +21,8 @@ export class SettingBase {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		defaultOnChangeListener: (changedValue: unknown, setting: SettingBase) => void = () => { /* Do nothing, to be overridden. */ }
     ) {
+        this.parseURLParams();
+
         this.onChange = defaultOnChangeListener;
 
         this.onChangeEmit = () => {
@@ -61,5 +65,60 @@ export class SettingBase {
         this._value = inValue;
         this.onChange(this._value, this);
         this.onChangeEmit(this._value);
+    }
+
+    /**
+     * Persist the setting value in URL.
+     */
+    public updateURLParams() {
+        if (this.useUrlParams) {
+            // set url params
+            const urlParams = new URLSearchParams(window.location.search);
+            const valueString = this.getValueAsString();
+            let set = false;
+            for (const [name, _value] of urlParams) {
+                if (name.toLowerCase() == this.id.toLowerCase()) {
+                    urlParams.set(name, valueString);
+                    set = true;
+                    break;
+                }
+            }
+            if (!set) {
+                urlParams.set(this.id, valueString);
+            }
+            window.history.replaceState(
+                {},
+                '',
+                urlParams.toString() !== ''
+                    ? `${location.pathname}?${urlParams}`
+                    : `${location.pathname}`
+            );
+        }
+    }
+
+    /**
+     * Allows sub types to provide their value for the url search params.
+     */
+    protected getValueAsString(): string {
+        return '';
+    }
+
+    private parseURLParams(): void {
+        this._urlParams = {};
+        const params = new URLSearchParams(window.location.search);
+        for (const [name, value] of params) {
+            this._urlParams[name.toLowerCase()] = value;
+        }
+    }
+
+    protected hasURLParam(name: string): boolean {
+        return name.toLowerCase() in this._urlParams;
+    }
+
+    protected getURLParam(name: string): string {
+        if (this.hasURLParam(name)) {
+            return this._urlParams[name.toLowerCase()];
+        }
+        return '';
     }
 }

--- a/Frontend/library/src/Config/SettingFlag.ts
+++ b/Frontend/library/src/Config/SettingFlag.ts
@@ -11,7 +11,6 @@ export class SettingFlag<
 > extends SettingBase {
     id: FlagsIds | CustomIds;
     onChangeEmit: (changedValue: boolean) => void;
-    useUrlParams: boolean;
 
     constructor(
         id: FlagsIds | CustomIds,
@@ -24,55 +23,18 @@ export class SettingFlag<
     ) {
         super(id, label, description, defaultFlagValue, defaultOnChangeListener);
 
-        const urlParams = new URLSearchParams(window.location.search);
-        if (!useUrlParams || !urlParams.has(this.id)) {
+        if (!useUrlParams || !this.hasURLParam(this.id)) {
             this.flag = defaultFlagValue;
         } else {
             // parse flag from url parameters
-            const urlParamFlag = this.getUrlParamFlag();
-            this.flag = urlParamFlag;
+            const urlParamFlag = this.getURLParam(this.id);
+            this.flag = urlParamFlag.toLowerCase() != 'false';
         }
         this.useUrlParams = useUrlParams;
     }
 
-    /**
-     * Parse the flag value from the url parameters.
-     * @returns True if the url parameters contains /?id, but False if /?id=false
-     */
-    getUrlParamFlag(): boolean {
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has(this.id)) {
-            if (
-                urlParams.get(this.id) === 'false' ||
-                urlParams.get(this.id) === 'False'
-            ) {
-                return false;
-            }
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Persist the setting value in URL.
-     */
-    public updateURLParams() {
-        if (this.useUrlParams) {
-            // set url params
-            const urlParams = new URLSearchParams(window.location.search);
-            if (this.flag === true) {
-                urlParams.set(this.id, 'true');
-            } else {
-                urlParams.set(this.id, 'false');
-            }
-            window.history.replaceState(
-                {},
-                '',
-                urlParams.toString() !== ''
-                    ? `${location.pathname}?${urlParams}`
-                    : `${location.pathname}`
-            );
-        }
+    protected getValueAsString(): string {
+        return this.flag ? 'true' : 'false';
     }
 
     /**

--- a/Frontend/library/src/Config/SettingNumber.ts
+++ b/Frontend/library/src/Config/SettingNumber.ts
@@ -14,7 +14,6 @@ export class SettingNumber<
 
     id: NumericParametersIds | CustomIds;
     onChangeEmit: (changedValue: number) => void;
-    useUrlParams: boolean;
 
     constructor(
         id: NumericParametersIds | CustomIds,
@@ -33,34 +32,17 @@ export class SettingNumber<
         this._max = max;
 
         // attempt to read the number from the url params
-        const urlParams = new URLSearchParams(window.location.search);
-        if (!useUrlParams || !urlParams.has(this.id)) {
+        if (!useUrlParams || !this.hasURLParam(this.id)) {
             this.number = defaultNumber;
         } else {
-            const parsedValue = Number.parseFloat(urlParams.get(this.id));
-            this.number = Number.isNaN(parsedValue)
-                ? defaultNumber
-                : parsedValue;
+            const parsedValue = Number.parseFloat(this.getURLParam(this.id));
+            this.number = Number.isNaN(parsedValue) ? defaultNumber : parsedValue;
         }
         this.useUrlParams = useUrlParams;
     }
 
-    /**
-     * Persist the setting value in URL.
-     */
-    public updateURLParams(): void {
-        if (this.useUrlParams) {
-            // set url params like ?id=number
-            const urlParams = new URLSearchParams(window.location.search);
-            urlParams.set(this.id, this.number.toString());
-            window.history.replaceState(
-                {},
-                '',
-                urlParams.toString() !== ''
-                    ? `${location.pathname}?${urlParams}`
-                    : `${location.pathname}`
-            );
-        }
+    protected getValueAsString(): string {
+        return this.number.toString();
     }
 
     /**

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -12,7 +12,6 @@ export class SettingOption<
     id: OptionParametersIds | CustomIds;
     onChangeEmit: (changedValue: string) => void;
     _options: Array<string>;
-    useUrlParams: boolean;
 
     constructor(
         id: OptionParametersIds | CustomIds,
@@ -27,43 +26,13 @@ export class SettingOption<
         super(id, label, description, defaultTextValue, defaultOnChangeListener);
 
         this.options = options;
-        const urlParams = new URLSearchParams(window.location.search);
-        const stringToMatch: string =
-            useUrlParams && urlParams.has(this.id)
-                ? this.getUrlParamText()
-                : defaultTextValue;
+        const stringToMatch: string = this.hasURLParam(this.id) ? this.getURLParam(this.id) : defaultTextValue;
         this.selected = stringToMatch;
         this.useUrlParams = useUrlParams;
     }
 
-    /**
-     * Parse the text value from the url parameters.
-     * @returns The text value parsed from the url if the url parameters contains /?id=value, but empty string if just /?id or no url param found.
-     */
-    getUrlParamText(): string {
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has(this.id)) {
-            return urlParams.get(this.id) ?? '';
-        }
-        return '';
-    }
-
-    /**
-     * Persist the setting value in URL.
-     */
-    public updateURLParams() {
-        if (this.useUrlParams) {
-            // set url params
-            const urlParams = new URLSearchParams(window.location.search);
-            urlParams.set(this.id, this.selected);
-            window.history.replaceState(
-                {},
-                '',
-                urlParams.toString() !== ''
-                    ? `${location.pathname}?${urlParams}`
-                    : `${location.pathname}`
-            );
-        }
+    protected getValueAsString(): string {
+        return this.selected;
     }
 
     /**

--- a/Frontend/library/src/Config/SettingText.ts
+++ b/Frontend/library/src/Config/SettingText.ts
@@ -24,45 +24,17 @@ export class SettingText<
     ) {
         super(id, label, description, defaultTextValue, defaultOnChangeListener);
 
-        const urlParams = new URLSearchParams(window.location.search);
-        if (!useUrlParams || !urlParams.has(this.id)) {
+        if (!useUrlParams || !this.hasURLParam(this.id)) {
             this.text = defaultTextValue;
         } else {
             // parse flag from url parameters
-            const urlParamFlag = this.getUrlParamText();
-            this.text = urlParamFlag;
+            this.text = this.getURLParam(this.id);
         }
         this.useUrlParams = useUrlParams;
     }
 
-    /**
-     * Parse the text value from the url parameters.
-     * @returns The text value parsed from the url if the url parameters contains /?id=value, but empty string if just /?id or no url param found.
-     */
-    getUrlParamText(): string {
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has(this.id)) {
-            return urlParams.get(this.id) ?? '';
-        }
-        return '';
-    }
-
-    /**
-     * Persist the setting value in URL.
-     */
-    public updateURLParams() {
-        if (this.useUrlParams) {
-            // set url params
-            const urlParams = new URLSearchParams(window.location.search);
-            urlParams.set(this.id, this.text);
-            window.history.replaceState(
-                {},
-                '',
-                urlParams.toString() !== ''
-                    ? `${location.pathname}?${urlParams}`
-                    : `${location.pathname}`
-            );
-        }
+    protected getValueAsString(): string {
+        return this.text;
     }
 
     /**

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -42,6 +42,7 @@ import {
     DataChannelLatencyTestResult
 } from "../DataChannel/DataChannelLatencyTestResults";
 import { RTCUtils } from '../Util/RTCUtils';
+import { IURLSearchParams } from '../Util/IURLSearchParams';
 
 
 export interface PixelStreamingOverrides {
@@ -575,7 +576,7 @@ export class PixelStreaming {
         }
 
         const useUrlParams = this.config.useUrlParams;
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = new IURLSearchParams(window.location.search);
         Logger.Info(
             Logger.GetStackTrace(),
             `using URL parameters ${useUrlParams}`

--- a/Frontend/library/src/Util/IURLSearchParams.ts
+++ b/Frontend/library/src/Util/IURLSearchParams.ts
@@ -1,0 +1,26 @@
+/**
+ * A case insensitive, partial implementation of URLSearchParams
+ */
+export class IURLSearchParams {
+    _urlParams : Record<string, string>;
+
+    constructor(search: string) {
+        this._urlParams = {};
+        const urlParams = new URLSearchParams(search);
+        for (const [name, value] of urlParams) {
+            this._urlParams[name.toLowerCase()] = value;
+        }
+    }
+
+    public has(name: string): boolean {
+        return name.toLowerCase() in this._urlParams;
+    }
+
+    public get(name: string): string | null {
+        if (this.has(name)) {
+            return this._urlParams[name.toLowerCase()];
+        }
+        return null;
+    }
+}
+

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -63,6 +63,10 @@ import {
     DataChannelLatencyTestRequest,
     DataChannelLatencyTestResponse
 } from "../DataChannel/DataChannelLatencyTestResults";
+import {
+    IURLSearchParams
+} from '../Util/IURLSearchParams';
+
 /**
  * Entry point for the WebRTC Player
  */
@@ -1368,7 +1372,7 @@ export class WebRtcPlayerController {
 
         // first we figure out a wanted streamer id through various means
         const useUrlParams = this.config.useUrlParams;
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = new IURLSearchParams(window.location.search);
         if (useUrlParams && urlParams.has(OptionParameters.StreamerId)) {
             // if we've set the streamer id on the url we only want that streamer id
             wantedStreamerId = urlParams.get(OptionParameters.StreamerId);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The URL parameters are case sensitive.

## Solution
We now handle the URL parameters in a case insensitive way.

Fixes #12 