### PR TITLE
Fix Firefox not streaming when using VPX codecs

### DIFF
--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -366,7 +366,7 @@ export class PeerConnectionController {
      */
     fuzzyIntersectUEAndBrowserCodecs(sdp: RTCSessionDescriptionInit) : string[] {
         // We want to build an array of all supported codecs on both sides
-        let allSupportedCodecs: Array<string> = new Array<string>();
+        const allSupportedCodecs: Array<string> = new Array<string>();
         const allUECodecs: string[] = this.parseAvailableCodecs(sdp);
         const allBrowserCodecs: string[] = this.config.getSettingOption(OptionParameters.PreferredCodec).options;
         for(const ueCodec of allUECodecs) {


### PR DESCRIPTION

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
In FireFox 128.0 FireFox add support for the [setCodecPreference](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/setCodecPreferences) API. This triggered a codepath that was previously only tested on Chrome to be executed. That codepath was unable to handle the slight difference codec parameters specified by Firefox and resulted in no codec being selected by the preferred codec API - meaning the browser would not display VPX video.

## Solution
The solution was to make this code path more robust to mismatched parameters and if the parameters are unable to be matched then it will fallback to only using the codec name. This should be robust to future browser changes in Chrome, FireFox, Safari, etc.

## Documentation
N/A

## Test Plan and Compatibility
Test with:

- FF + H.264
- FF + VP8
- Chrome + VP8
- Chrome + H.264

All are able to connect.