### PR TITLE
Fix: Mobile UI not scaling correctly when nav bars are present.

### DIFF
--- a/Frontend/implementations/typescript/src/player.html
+++ b/Frontend/implementations/typescript/src/player.html
@@ -21,7 +21,7 @@
 </head>
 
 <!-- The Pixel Streaming player fills 100% of its parent element but body has a 0px height unless filled with content. As such, we explicitly force the body to be 100% of the viewport height -->
-<body style="width: 100vw; height: 100dvh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
+<body style="width: 100vw; height: 100svh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
 
 </body>
 

--- a/Frontend/implementations/typescript/src/player.html
+++ b/Frontend/implementations/typescript/src/player.html
@@ -21,7 +21,7 @@
 </head>
 
 <!-- The Pixel Streaming player fills 100% of its parent element but body has a 0px height unless filled with content. As such, we explicitly force the body to be 100% of the viewport height -->
-<body style="width: 100vw; height: 100vh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
+<body style="width: 100vw; height: 100dvh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
 
 </body>
 


### PR DESCRIPTION
## Relevant components:
- [x] Examples

## Problem statement:
Mobile UI was not scaling properly when match viewport resolution was used and mobile nav bars were present.

See here clipped UI:

![image](https://github.com/user-attachments/assets/e5d9869f-5b8c-49f0-bcf4-3f0cf36639e0)


## Solution
Parent container for Pixel Streaming should use dynamic viewport height, e.g. `100dvh`

`dvh` units are documented here: https://developer.mozilla.org/en-US/docs/Web/CSS/length#dynamic

They are compliant with all modern browsers.

When this fix is applied above UI looks like this:

![image](https://github.com/user-attachments/assets/40e43cb7-c782-46f8-b82e-70ac8c889de9)


## Documentation
N/A

## Test Plan and Compatibility
- Tested with customer to confirm fix
- Tested with Chrome + PC
- Tested with Firefox + PC
- Tested with Android + Chrome
- Tested with Safari + iPhone
- Tested with Chrome + iPhone
