### PR TITLE
Disable fullscreen button showing on iPhone

### DIFF
--- a/Frontend/implementations/typescript/src/player.html
+++ b/Frontend/implementations/typescript/src/player.html
@@ -21,7 +21,7 @@
 </head>
 
 <!-- The Pixel Streaming player fills 100% of its parent element but body has a 0px height unless filled with content. As such, we explicitly force the body to be 100% of the viewport height -->
-<body style="width: 100vw; height: 100dvh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
+<body style="width: 100vw; height: 100svh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
 
 </body>
 

--- a/Frontend/implementations/typescript/src/player.html
+++ b/Frontend/implementations/typescript/src/player.html
@@ -21,7 +21,7 @@
 </head>
 
 <!-- The Pixel Streaming player fills 100% of its parent element but body has a 0px height unless filled with content. As such, we explicitly force the body to be 100% of the viewport height -->
-<body style="width: 100vw; height: 100vh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
+<body style="width: 100vw; height: 100dvh; min-height: -webkit-fill-available; font-family: 'Montserrat'; margin: 0px">
 
 </body>
 

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -185,6 +185,14 @@ export class Application {
      * Set up button click functions and button functionality
      */
     public createButtons() {
+
+        // IPhone does not support fullscreen API as at 28th July 2024 (see: https://caniuse.com/fullscreen) so if
+        // we are on IPhone and user has not specified explicitly configured UI config for
+        // fullscreen button then we should disable this button as it doesn't work.
+        if(this._options.fullScreenControlsConfig === undefined && /iPhone/.test(navigator.userAgent)) {
+            this._options.fullScreenControlsConfig = { creationMode: UIElementCreationMode.Disable };
+        }
+
         const controlsUIConfig : ControlsUIConfiguration = {
             statsButtonType : this._options.statsPanelConfig
                 ? this._options.statsPanelConfig.visibilityButtonConfig
@@ -195,6 +203,7 @@ export class Application {
             fullscreenButtonType: this._options.fullScreenControlsConfig,
             xrIconType: this._options.xrControlsConfig
         }
+
         // Setup controls
         const controls = new Controls(controlsUIConfig);
         this.uiFeaturesElement.appendChild(controls.rootElement);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Fullscreen button does not work on iPhone due to lack of fullscreen API on iPhone. 

See here: https://caniuse.com/fullscreen

Note: Fullscreen is supported on Safari + iPad and Safari + Mac, but specifically does not work well for iPhone.

## Solution
Disable showing the fullscreen button when we are iPhone.

## Documentation
N/A

## Test Plan and Compatibility
Tested on:

iPhone + Safari = No button
Chrome + PC = Button is visible
