### PR TITLE
[UE5.4] Restoring https usage with matchmaker

### DIFF
--- a/Matchmaker/matchmaker.js
+++ b/Matchmaker/matchmaker.js
@@ -71,9 +71,10 @@ if (config.UseHTTPS) {
 			if (req.get('Host')) {
 				var hostAddressParts = req.get('Host').split(':');
 				var hostAddress = hostAddressParts[0];
-				if (httpsPort != 443) {
-					hostAddress = `${hostAddress}:${httpsPort}`;
-				}
+				// this seems like a broken copy/paste
+				// if (httpsPort != 443) {
+				// 	hostAddress = `${hostAddress}:${httpsPort}`;
+				// }
 				return res.redirect(['https://', hostAddress, req.originalUrl].join(''));
 			} else {
 				console.error(`unable to get host name from header. Requestor ${req.ip}, url path: '${req.originalUrl}', available headers ${JSON.stringify(req.headers)}`);
@@ -152,7 +153,8 @@ if(enableRedirectionLinks) {
 	app.get('/', (req, res) => {
 		cirrusServer = getAvailableCirrusServer();
 		if (cirrusServer != undefined) {
-			res.redirect(`http://${cirrusServer.address}:${cirrusServer.port}/`);
+			let prefix = cirrusServer.https ? 'https://' : 'http://';
+			res.redirect(`${prefix}${cirrusServer.address}:${cirrusServer.port}/`);
 			//console.log(req);
 			console.log(`Redirect to ${cirrusServer.address}:${cirrusServer.port}`);
 		} else {
@@ -164,7 +166,8 @@ if(enableRedirectionLinks) {
 	app.get('/custom_html/:htmlFilename', (req, res) => {
 		cirrusServer = getAvailableCirrusServer();
 		if (cirrusServer != undefined) {
-			res.redirect(`http://${cirrusServer.address}:${cirrusServer.port}/custom_html/${req.params.htmlFilename}`);
+			let prefix = cirrusServer.https ? 'https://' : 'http://';
+			res.redirect(`${prefix}${cirrusServer.address}:${cirrusServer.port}/custom_html/${req.params.htmlFilename}`);
 			console.log(`Redirect to ${cirrusServer.address}:${cirrusServer.port}`);
 		} else {
 			sendRetryResponse(res);
@@ -200,6 +203,7 @@ const matchmaker = net.createServer((connection) => {
 			cirrusServer = {
 				address: message.address,
 				port: message.port,
+				https: message.https,
 				numConnectedClients: 0,
 				lastPingReceived: Date.now()
 			};

--- a/Matchmaker/matchmaker.js
+++ b/Matchmaker/matchmaker.js
@@ -71,10 +71,6 @@ if (config.UseHTTPS) {
 			if (req.get('Host')) {
 				var hostAddressParts = req.get('Host').split(':');
 				var hostAddress = hostAddressParts[0];
-				// this seems like a broken copy/paste
-				// if (httpsPort != 443) {
-				// 	hostAddress = `${hostAddress}:${httpsPort}`;
-				// }
 				return res.redirect(['https://', hostAddress, req.originalUrl].join(''));
 			} else {
 				console.error(`unable to get host name from header. Requestor ${req.ip}, url path: '${req.originalUrl}', available headers ${JSON.stringify(req.headers)}`);
@@ -155,7 +151,6 @@ if(enableRedirectionLinks) {
 		if (cirrusServer != undefined) {
 			let prefix = cirrusServer.https ? 'https://' : 'http://';
 			res.redirect(`${prefix}${cirrusServer.address}:${cirrusServer.port}/`);
-			//console.log(req);
 			console.log(`Redirect to ${cirrusServer.address}:${cirrusServer.port}`);
 		} else {
 			sendRetryResponse(res);

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -1015,6 +1015,7 @@ if (config.UseMatchmaker) {
 		message = {
 			type: 'connect',
 			address: typeof serverPublicIp === 'undefined' ? '127.0.0.1' : serverPublicIp,
+			https: config.UseHTTPS,
 			port: config.UseHTTPS ? httpsPort : httpPort,
 			ready: streamers.size > 0,
 			playerConnected: playerConnected


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [x] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Matchmaker was not working when HTTPS was in use
See #225

## Solution
The matchmaker was not properly detecting that servers were using https. These changes clean up the behaviour and allow the MM to properly redirect to HTTPS servers again.

