### PR TITLE
Update AggregatedStats.ts

### DIFF
--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -19,7 +19,7 @@ import { Logger } from '../Logger/Logger';
  * The Aggregated Stats that is generated from the RTC Stats Report
  */
 
-type RTCStatsTypePS = RTCStatsType | 'stream' | 'media-playout';
+type RTCStatsTypePS = RTCStatsType | 'stream' | 'media-playout' | 'track';
 export class AggregatedStats {
     inboundVideoStats: InboundVideoStats;
     inboundAudioStats: InboundAudioStats;


### PR DESCRIPTION
added missing type option in RTCStatsTypePS of 'track';
i was getting error while compiling without webpack
![image](https://github.com/user-attachments/assets/1b0d8a1c-3baa-4e82-b431-1edf8f82d0f5)

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU


## Problem statement:
getting error while compiling without webpack or it is visible in my vscode 

## Solution
by adding missing type option in RTCStatsTypePS of 'track';
