### PR TITLE
Change --no-save to --save in Wilbur

### DIFF
--- a/SignallingWebServer/.gitignore
+++ b/SignallingWebServer/.gitignore
@@ -1,4 +1,5 @@
 build/
 node_modules/
 www/
+config.json
 ssl/

--- a/SignallingWebServer/.gitignore
+++ b/SignallingWebServer/.gitignore
@@ -1,5 +1,4 @@
 build/
 node_modules/
 www/
-config.json
 ssl/

--- a/SignallingWebServer/README.md
+++ b/SignallingWebServer/README.md
@@ -74,9 +74,8 @@ Options:
   --no_config                       Skips the reading of the config file. Only CLI options will be used. (default:
                                     false)
   --config_file <path>              Sets the path of the config file. (default: "config.json")
-  --no_save                         On startup the given configuration is resaved out to config.json. This switch will
-                                    prevent this behaviour allowing the config.json file to remain untouched while
-                                    running with new configurations. (default: false)
+  --save                            After arguments are parsed the config.json is saved with whatever arguments were
+                                    specified at launch. (default: false)
   -h, --help                        Display this help text.
 ```
 These CLI options can also be described in a `config.json` (default config file overridable with --config_file) by specifying the command option name and value in a simple JSON object. eg.

--- a/SignallingWebServer/config.json
+++ b/SignallingWebServer/config.json
@@ -1,0 +1,21 @@
+{
+	"log_folder": "logs",
+	"log_level_console": "info",
+	"log_level_file": "info",
+	"streamer_port": "8888",
+	"player_port": "80",
+	"sfu_port": "8889",
+	"serve": true,
+	"http_root": "D:\\PixelStreamingInfrastructure\\SignallingWebServer\\www",
+	"homepage": "player.html",
+	"https": false,
+	"https_port": 443,
+	"ssl_key_path": "certificates/client-key.pem",
+	"ssl_cert_path": "certificates/client-cert.pem",
+	"https_redirect": true,
+	"rest_api": false,
+	"peer_options": "",
+	"log_config": true,
+	"stdin": false,
+	"console_messages": "verbose"
+}

--- a/SignallingWebServer/from_cirrus.md
+++ b/SignallingWebServer/from_cirrus.md
@@ -3,10 +3,11 @@
 This is just a small brief to describe the differences between the now deprecated `cirrus` signalling server and the new `wilbur` signalling server.
 
 - Configuration is handled by CLI options or the same options in a `config.json`
-- By default web serving is disabled but can be enabled by supplying --serve
-- Convenience scripts in `platform_scripts' will append --serve and try to preproduce old cirrus behaviour.
-- Frontend will be placed in `www` instead of `Public` when using convenience scripts.
+- By default web serving is disabled but can be enabled by supplying `--serve`
+- Convenience scripts in `platform_scripts` will append `--serve` and try to reproduce the old `cirrus.js` behaviour.
+- The frontend will be placed in `www` instead of `Public` when using convenience scripts.
 - Messages are now described by protobufs in the [Common](../Common/protobuf/signalling_messages.proto) library.
 - The server is built on top of the [Common](../Common) library which is provided as a tool for developers to build their own applications.
-- Logs from wilbur are now structured JSON so they can be easily ingested into external tools.
-- Messages sent and received are no longer echoed to the terminal by default. The --console_messages argument can control this behaviour.
+- Logs from `wilbur` are now structured JSON so they can be easily ingested into external tools.
+- Messages sent and received are no longer echoed to the terminal by default. The `--console_messages` argument can control this behaviour.
+- The `config.json` file will not be created or recreated (if deleted), if you want the config.json to be generated based on current arguments use `--save`.

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -86,7 +86,7 @@ program
         .default(config_file.peer_options || ""))
     .option('--log_config', 'Will print the program configuration on startup.', config_file.log_config || false)
     .option('--stdin', 'Allows stdin input while running.', config_file.stdin || false)
-    .option('--no_save', 'On startup the given configuration is resaved out to config.json. This switch will prevent this behaviour allowing the config.json file to remain untouched while running with new configurations.', config_file.no_save || false)
+    .option('--save', 'After arguments are parsed the config.json is saved with whatever arguments were specified at launch.', config_file.save || false)
     .helpOption('-h, --help', 'Display this help text.')
     .allowUnknownOption() // ignore unknown options which will allow versions to be swapped out into existing scripts with maybe older/newer options
     .parse();
@@ -96,13 +96,13 @@ const cli_options: IProgramOptions = program.opts();
 const options: IProgramOptions = { ...cli_options };
 
 // save out new configuration (unless disabled)
-if (!options.no_save) {
+if (options.save) {
 
     // dont save certain options
     const save_options = { ...options };
     delete save_options.no_config;
     delete save_options.config_file;
-    delete save_options.no_save;
+    delete save_options.save;
 
     // save out the config file with the current settings
     fs.writeFile(configArgsParser.config_file, beautify(save_options), (error: any) => {


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
In previous versions of the PSInfra the `config.json` file was not overridden with arguments passed at launch. The current behaviour means by default `config.json` changes as a user passes launch args. This change in behaviour has confused some users already.

## Solution
This PR changes the `--no-save` argument to be a `--save` argument, which is `false` by default. This means the `config.json` file will only be written when `--save` is specified. The side effect is this means a `config.json` will not be generated when the user intially runs `start.bat`. This makes discovery of the configuration options a little more hidden (because no one reads the docs apparently). To mitigate this discovery issue I have also committed a default `config.json` file (and subsequently `.gitignore`'d it so that it will not be committed by PSInfra devs during our work).

## Documentation
I have updated the docs regarding the `--no-save` becoming `--save`.

## Test Plan and Compatibility
I have given this a few local tests on Windows, both with and without `config.json` present. I have not tested this on Linux/Mac, but I do not foresee any issues there as this is a pure NodeJS code change, so it should be cross platform.
