### PR TITLE
Specify vp8 encoder when doing linux stream test

### DIFF
--- a/Extras/MinimalStreamTester/docker-compose.yml
+++ b/Extras/MinimalStreamTester/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   streamer:
     image: pixelstreamingunofficial/ps-minimal-streamer-linux
-    command: -PixelStreamingURL=ws://signalling:8888 -nothreadtimeout
+    command: -PixelStreamingURL=ws://signalling:8888 -nothreadtimeout -PixelStreamingEncoderCodec=vp8
     networks:
       - testing
     healthcheck:

--- a/Extras/MinimalStreamTester/tests/stream_test.spec.ts
+++ b/Extras/MinimalStreamTester/tests/stream_test.spec.ts
@@ -30,7 +30,7 @@ test('Test default stream.', async ({ page }, testinfo) => {
     await waitForVideo(page);
 
     // let the stream run for a small duration
-    await delay(15000);
+    await delay(30000);
 
     // query the frontend for its calculated stats
     const frame_count:number = await page.evaluate(()=> {


### PR DESCRIPTION
As the stream test occurs on GHA that has no GPU we must specify use of vp8 so we hit a CPU encoding code path.

## Relevant components:
- [x] Github actions

## Problem statement:
The Linux stream currently streams a black stream.

## Solution
This PR explicitly sets vp8 encoding so we use a cpu encoding code path. This is necessary as the Github actions we use do not have a GPU attached.
