### PR TITLE
Add logging about streamer disconnecting

### DIFF
--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -121,7 +121,7 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
     }
 
     private onTransportClose(): void {
-        Logger.debug('StreamerConnection transport close.');
+        Logger.info(`Streamer '${this.streamerId}' - websocket disconnected.`);
         this.emit('disconnect');
     }
 


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
There is no indication of the streamer disconnecting without debug logging. In previous versions, this was part of the standard logging.

## Solution
Restore streamer disconnect logging as part of the standard logging that occurs when you run start.bat

## Documentation
N/A

## Test Plan and Compatibility
Tested locally on Windows and using this PR.
