### PR TITLE
Add support for configurable countdown value for AFKTimeout

### DIFF
--- a/Frontend/Docs/Timing Out Inactive Connections.md
+++ b/Frontend/Docs/Timing Out Inactive Connections.md
@@ -15,9 +15,10 @@ Any user interaction with the player panel resets the AFK timer. This includes m
 To use the AFK system, set the following properties in the [`Config`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/library/src/Config/Config.ts) object passed used to create a [`PixelStreaming`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/library/src/PixelStreaming/PixelStreaming.ts) stream.
 
 | Property | Default | Description |
-|    ---   | --- |
+|    ---   |   ---   |     ---     |
 | `Flags.AFKDetection` | `false` | Determines whether the AFK system should check for user interactions. |
 | `NumericParameters.AFKTimeoutSecs` | `120` | Sets the maximum time interval, in seconds, that the user can remain away from keyboard before seeing a warning overlay in the player widget. |
+| `NumericParameters.AFKCountdown` | `10` | Sets the duration of the countdown, in seconds, before the stream is terminated if a user does not respond in time. |
 
 For example, to activate AFK Detection and set it to kick in after five minutes, you would do the following in your implementation:
 
@@ -25,10 +26,10 @@ For example, to activate AFK Detection and set it to kick in after five minutes,
 const config = new Config({ useUrlParams: true });
 config.setFlagEnabled(Flags.AFKDetection, true);
 config.setNumericSetting(NumericParameters.AFKTimeoutSecs, 300);
+config.setNumericSetting(NumericParameters.AFKCountdown, 60);
 
 const stream = new PixelStreaming(config);
 ```
 
 **_Tip:_**
 If you want to customize the content of the overlay, you can replace the [`AFKOverlay`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/ui-library/src/Overlay/AFKOverlay.ts) class. You must then also extend the [`Application`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/ui-library/src/Application/Application.ts) class in order to use the new overlay.
-

--- a/Frontend/library/src/AFK/AFKController.ts
+++ b/Frontend/library/src/AFK/AFKController.ts
@@ -12,7 +12,6 @@ import {
 
 export class AFKController {
     // time out logic details
-    closeTimeout = 10;
     active = false;
     countdownActive = false;
     warnTimer: ReturnType<typeof setTimeout> = undefined;
@@ -118,7 +117,9 @@ export class AFKController {
         );
 
         // update our countDown timer and overlay contents
-        this.countDown = this.closeTimeout;
+        this.countDown = this.config.getNumericSettingValue(
+            NumericParameters.AFKCountdownSecs
+        );
         this.countdownActive = true;
         this.pixelStreaming.dispatchEvent(
             new AfkWarningUpdateEvent({ countDown: this.countDown })

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -48,6 +48,7 @@ const isFlagId = (id: string): id is FlagsIds =>
  */
 export class NumericParameters {
     static AFKTimeoutSecs = 'AFKTimeout' as const;
+    static AFKCountdownSecs = 'AFKCountdown' as const;
     static MinQP = 'MinQP' as const;
     static MaxQP = 'MaxQP' as const;
     static WebRTCFPS = 'WebRTCFPS' as const;
@@ -519,6 +520,19 @@ export class Config {
                 useUrlParams
             )
         );
+
+        this.numericParameters.set(
+            NumericParameters.AFKCountdownSecs,
+            new SettingNumber(
+                NumericParameters.AFKCountdownSecs,
+                'AFK countdown',
+                'The time (in seconds) for a user to respond before the stream is ended after an AFK timeout.',
+                10 /*min*/,
+                180 /*max*/,
+                10 /*value*/,
+                useUrlParams
+            )
+        )
 
         this.numericParameters.set(
             NumericParameters.MaxReconnectAttempts,

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -200,6 +200,10 @@ export class ConfigUI {
         );
         this.addSettingNumeric(
             psSettingsSection,
+            this.numericParametersUi.get(NumericParameters.AFKCountdownSecs)
+        );
+        this.addSettingNumeric(
+            psSettingsSection,
             this.numericParametersUi.get(NumericParameters.MaxReconnectAttempts)
         );
         this.addSettingNumeric(


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:

As a user of the **PixelStreamingInfrastructure** library, I would like to be able to configure the countdown provided to users after an AFK timeout has elapsed. Currently this countdown value is hardcoded to 10 seconds.

## Solution

This PR adds a new `NumericParameter` called `AFKCountdown` which can be configured at the same time as other AFK properties when the `PixelStream` is first created. The default value is 10 seconds, but this can be set to be a total of 3 minutes if desired (this upper limit can totally be adjusted based on PR feeedback, the duration we'd like to use on our team is 60 seconds).

## Documentation

I have updated `Frontend/Docs/Timing Out Inactive Connections.md` to include a reference to the new variable/setting (I also fixed the formatting of the Markdown table which wasn't rendering correctly). 

## Test Plan and Compatibility

I have not yet created tests to verify the feature yet (if this is something required for the PR I wanted to wait to get the feedback/comments first).

I did find existing tests in `AFKController.test.ts` which exercise the countdown feature (see test `'should activate AFK timer and trigger it after specified delay if it has been enabled from settings'`). I'd be happy to update this test to verify a different number of seconds for the countdown if that would be useful.

## Context

We initially created this change off of the [UE5.3-1.0.4](https://github.com/revu-design/PixelStreamingInfrastructure/releases/tag/UE5.3-1.0.4) tag that we're using for our project. The changes have been rebased onto the master branch for this PR.
