### PR TITLE
Support flexfec, ulpfec, and any other non-video video codecs.

### DIFF
--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -409,7 +409,6 @@ export class PeerConnectionController {
             this.peerConnection?.addTransceiver('video', { direction: 'recvonly' });
         }
 
-        // We can only set preferred codec on Chrome
         if (RTCRtpReceiver.getCapabilities && this.preferredCodec != '') {
             for (const transceiver of this.peerConnection?.getTransceivers() ?? []) {
                 if (
@@ -419,44 +418,36 @@ export class PeerConnectionController {
                     transceiver.receiver.track.kind === 'video' &&
                     transceiver.setCodecPreferences
                 ) {
+                    // Get our preferred codec from the codecs options drop down
                     const preferredRTPCodec = this.preferredCodec.split(' ');
-                    const codecs = [
-                        {
-                            mimeType:
-                                'video/' + preferredRTPCodec[0] /* Name */,
-                            clockRate: 90000,
-                            sdpFmtpLine: preferredRTPCodec[1] /* sdpFmtpLine */
-                                ? preferredRTPCodec[1]
-                                : ''
+                    const preferredRTCRtpCodecCapability: RTCRtpCodecCapability = {
+                        mimeType: 'video/' + preferredRTPCodec[0] /* Name */,
+                        clockRate: 90000, /* All current video formats in browsers have 90khz clock rate */
+                        sdpFmtpLine: preferredRTPCodec[1] ? preferredRTPCodec[1] : ''
+                    }
+
+                    // Populate a list of codecs we will support with our preferred one in the first position
+                    const ourSupportedCodecs: Array<RTCRtpCodecCapability> = [preferredRTCRtpCodecCapability];
+
+                    // Go through all codecs the browser supports and add them to the list (in any order)
+                    RTCRtpReceiver.getCapabilities('video').codecs.forEach((browserSupportedCodec : RTCRtpCodecCapability) => {
+                        // Don't add our preferred codec again, but add everything else
+                        if(browserSupportedCodec.mimeType != preferredRTCRtpCodecCapability.mimeType) {
+                            ourSupportedCodecs.push(browserSupportedCodec);
                         }
-                    ];
+                        else if(browserSupportedCodec?.sdpFmtpLine != preferredRTCRtpCodecCapability?.sdpFmtpLine) {
+                            ourSupportedCodecs.push(browserSupportedCodec);
+                        }
+                    });
 
-                    this.config
-                        .getSettingOption(OptionParameters.PreferredCodec)
-                        .options.filter((option) => {
-                            // Remove the preferred codec from the list of possible codecs as we've set it already
-                            return option != this.preferredCodec;
-                        })
-                        .forEach((option) => {
-                            // Amend the rest of the browsers supported codecs
-                            const altCodec = option.split(' ');
-                            codecs.push({
-                                mimeType: 'video/' + altCodec[0] /* Name */,
-                                clockRate: 90000,
-                                sdpFmtpLine: altCodec[1] /* sdpFmtpLine */
-                                    ? altCodec[1]
-                                    : ''
-                            });
-                        });
-
-                    for (const codec of codecs) {
-                        if (codec.sdpFmtpLine === '') {
+                    for (const codec of ourSupportedCodecs) {
+                        if (codec?.sdpFmtpLine === undefined || codec.sdpFmtpLine === '') {
                             // We can't dynamically add members to the codec, so instead remove the field if it's empty
                             delete codec.sdpFmtpLine;
                         }
                     }
 
-                    transceiver.setCodecPreferences(codecs);
+                    transceiver.setCodecPreferences(ourSupportedCodecs);
                 }
             }
         }

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -185,6 +185,14 @@ export class Application {
      * Set up button click functions and button functionality
      */
     public createButtons() {
+
+        // IPhone does not support fullscreen API as at 28th July 2024 (see: https://caniuse.com/fullscreen) so if
+        // we are on IPhone and user has not specified explicitly configured UI config for
+        // fullscreen button then we should disable this button as it doesn't work.
+        if(this._options.fullScreenControlsConfig === undefined && /iPhone/.test(navigator.userAgent)) {
+            this._options.fullScreenControlsConfig = { creationMode: UIElementCreationMode.Disable };
+        }
+
         const controlsUIConfig : ControlsUIConfiguration = {
             statsButtonType : this._options.statsPanelConfig
                 ? this._options.statsPanelConfig.visibilityButtonConfig
@@ -195,6 +203,7 @@ export class Application {
             fullscreenButtonType: this._options.fullScreenControlsConfig,
             xrIconType: this._options.xrControlsConfig
         }
+
         // Setup controls
         const controls = new Controls(controlsUIConfig);
         this.uiFeaturesElement.appendChild(controls.rootElement);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The current code pruned the list of supported codecs to only include h.264, vpx, av1, but this meant error correction codecs like flexfec, ulpfec, and so on were removed from the browsers sdp (even though they are supported!).

## Solution
This PR does not prune any codecs, but instead puts our preferred codec at the top and then adds all the other supported codecs.

## Documentation
N/A

## Test Plan and Compatibility
This has been tested on my machine and @gingernaz's machine and flexfec successfully is shown in the supported codecs and WebRTC stats using this PR.

This PR makes https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/46 redundant.
