### PR TITLE
Add: Scalability mode support to the SFU

### DIFF
--- a/SFU/config.js
+++ b/SFU/config.js
@@ -18,10 +18,13 @@ const config = {
   SFUId: "SFU",
 
   // The ID of the streamer to subscribe to. If you leave this blank it will subscribe to the first streamer it sees.
-  subscribeStreamerId: "DefaultStreamer",
+  subscribeStreamerId: "",
 
   // Delay between list requests when looking for a specifc streamer.
   retrySubscribeDelaySecs: 10,
+
+  // Enable SVC support
+  enableSVC: true,
 
   mediasoup: {
     worker: {
@@ -55,11 +58,7 @@ const config = {
           kind: 'video',
           mimeType: 'video/VP8',
           clockRate: 90000,
-          parameters: {
-            "packetization-mode": 1,
-            "profile-level-id": "42e01f",
-            "level-asymmetry-allowed": 1
-          }
+          parameters: {}
         },
         {
           kind: "video",
@@ -85,6 +84,28 @@ const config = {
       initialAvailableOutgoingBitrate: 100_000_000,
     },
   },
+}
+
+if(config.enableSVC)
+{
+  config.mediasoup.router.mediaCodecs.push(
+  {
+    kind: 'video',
+    mimeType: 'video/VP9',
+    clockRate: 90000,
+    parameters: {
+      "profile-id": 0
+    }
+  });
+  config.mediasoup.router.mediaCodecs.push(
+  {
+    kind: 'video',
+    mimeType: 'video/VP9',
+    clockRate: 90000,
+    parameters: {
+      "profile-id": 2
+    }
+  });
 }
 
 function getLocalListenIps() {

--- a/SFU/config.js
+++ b/SFU/config.js
@@ -18,7 +18,7 @@ const config = {
   SFUId: "SFU",
 
   // The ID of the streamer to subscribe to. If you leave this blank it will subscribe to the first streamer it sees.
-  subscribeStreamerId: "",
+  subscribeStreamerId: "DefaultStreamer",
 
   // Delay between list requests when looking for a specifc streamer.
   retrySubscribeDelaySecs: 10,

--- a/SFU/mediasoup-sdp-bridge/lib/SdpUtils.js
+++ b/SFU/mediasoup-sdp-bridge/lib/SdpUtils.js
@@ -42,7 +42,7 @@ function sdpToRecvRtpCapabilities(sdpObject, localCaps) {
     return recvCaps;
 }
 exports.sdpToRecvRtpCapabilities = sdpToRecvRtpCapabilities;
-function sdpToSendRtpParameters(sdpObject, sdpMediaObj, localCaps, kind) {
+function sdpToSendRtpParameters(sdpObject, sdpMediaObj, localCaps, kind, scalabilityMode) {
     var _a;
     const caps = MsSdpUtils.extractRtpCapabilities({
         sdpObject,
@@ -75,6 +75,13 @@ function sdpToSendRtpParameters(sdpObject, sdpMediaObj, localCaps, kind) {
         //     kind,
         // });
         sendParams.encodings = MsRtpUtils.getRtpEncodings({ offerMediaObject: sdpMediaObj });
+        if(kind === "video")
+        {
+            for(let encoding of sendParams.encodings)
+            {
+                encoding.scalabilityMode = scalabilityMode;
+            }
+        }
     }
     sendParams.rtcp = {
         cname: MsSdpUtils.getCname({ offerMediaObject: sdpMediaObj }),

--- a/SFU/mediasoup-sdp-bridge/lib/index.js
+++ b/SFU/mediasoup-sdp-bridge/lib/index.js
@@ -39,7 +39,7 @@ class SdpEndpoint {
         this.sctpMedia = null;
         this.consumeData = false;
     }
-    async processOffer(sdpOffer) {
+    async processOffer(sdpOffer, scalabilityMode) {
         if (this.remoteSdp) {
             console.error("[SdpEndpoint.processOffer] ERROR: A remote description was already set");
             return [];
@@ -63,7 +63,7 @@ class SdpEndpoint {
                 if (!("direction" in media)) {
                     continue;
                 }
-                const sendParams = SdpUtils.sdpToSendRtpParameters(remoteSdpObj, media, this.localCaps, media.type);
+                const sendParams = SdpUtils.sdpToSendRtpParameters(remoteSdpObj, media, this.localCaps, media.type, scalabilityMode);
                 let producer;
                 try {
                     producer = await this.transport.produce({

--- a/SFU/mediasoup-sdp-bridge/lib/index.js
+++ b/SFU/mediasoup-sdp-bridge/lib/index.js
@@ -63,9 +63,6 @@ class SdpEndpoint {
                 if (!("direction" in media)) {
                     continue;
                 }
-                if (media.direction !== "sendonly") {
-                    continue;
-                }
                 const sendParams = SdpUtils.sdpToSendRtpParameters(remoteSdpObj, media, this.localCaps, media.type);
                 let producer;
                 try {

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -58,7 +58,7 @@ async function onIdentify(msg) {
   signalServer.send(JSON.stringify({type: 'listStreamers'}));
 }
 
-async function onStreamerOffer(sdp) {
+async function onStreamerOffer(msg) {
   console.log("Got offer from streamer");
 
   if (streamer != null) {
@@ -68,7 +68,7 @@ async function onStreamerOffer(sdp) {
 
   const transport = await createWebRtcTransport("Streamer");
   const sdpEndpoint = mediasoupSdp.createSdpEndpoint(transport, mediasoupRouter.rtpCapabilities);
-  const producers = await sdpEndpoint.processOffer(sdp);
+  const producers = await sdpEndpoint.processOffer(msg.sdp, msg.scalabilityMode ? msg.scalabilityMode : "L1T1");
   const sdpAnswer = sdpEndpoint.createAnswer();
   const answer = { type: "answer", sdp: sdpAnswer };
 
@@ -271,7 +271,7 @@ async function onSignallingMessage(message) {
   const msg = JSON.parse(message);
 
   if (msg.type == 'offer') {
-    onStreamerOffer(msg.sdp);
+    onStreamerOffer(msg);
   }
   else if (msg.type == 'answer') {
     onPeerAnswer(msg.playerId, msg.sdp);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [X] SFU

## Problem statement:
VP9 doesn't support simulcast, but instead supports SVC. Currently, the SFU configuration doesn't enable VP9 and therefore no SVC support.

## Solution
This PR adds a configuration option for the SFU to enable VP9. With this option enabled, VP9 can be negotiated. Additionally, the SFU now looks for a `scalabiltityMode` member in the `Offer` message to know which `scalabilityMode` to use. This is required as this information is expected to be communicated out of band as per the SVC spec. This addition of `scalabilityMode` is required to support Pixel Streaming 2 SFU support where scalability mode is now the only way the SFU can specify what types of encoded layers it has.
