### PR TITLE
Fixed touch with virtual joystick issues.

### DIFF
--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -399,7 +399,7 @@ export class Config {
                 'A single finger touch is converted into a mouse event. This allows a non-touch application to be controlled partially via a touch device.',
                 settings && Object.prototype.hasOwnProperty.call(settings, Flags.FakeMouseWithTouches)
                     ? settings[Flags.FakeMouseWithTouches]
-                    : true,
+                    : false,
                 useUrlParams
             )
         );

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -168,6 +168,13 @@ export class PixelStreaming {
             this._webRtcController.setMouseInputEnabled(isEnabled);
         });
 
+        this.config._addOnSettingChangedListener(
+            Flags.FakeMouseWithTouches,
+            (_isFakeMouseEnabled: boolean) => {
+                this._webRtcController.setTouchInputEnabled(this.config.isFlagEnabled(Flags.TouchInput));
+            }
+        );
+
         this.config._addOnSettingChangedListener(Flags.TouchInput, (isEnabled: boolean) => {
             this._webRtcController.setTouchInputEnabled(isEnabled);
         });

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -167,6 +167,8 @@ export class ConfigUI {
 
         this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.MouseInput));
 
+        this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.FakeMouseWithTouches));
+
         this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.TouchInput));
 
         this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.GamepadInput));


### PR DESCRIPTION
The fake mouse input with touch was accidentally defaulted to true which prevented touch inputs interacting with the virtual joystick.
This has now defaulted back to false, and the option has been added to the settings panel so the current state can be visualised and toggled at will.
