### PR TITLE
Update max value for AFK countdown and timeout

### DIFF
--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -506,10 +506,10 @@ export class Config {
                 'AFK timeout',
                 'The time (in seconds) it takes for the application to time out if AFK timeout is enabled.',
                 0 /*min*/,
-                600 /*max*/,
+                3600 /*max - 1 hour*/,
                 settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.AFKTimeoutSecs)
                     ? settings[NumericParameters.AFKTimeoutSecs]
-                    : 120 /*value*/,
+                    : 120 /*default value - 2 minutes*/,
                 useUrlParams
             )
         );
@@ -520,9 +520,11 @@ export class Config {
                 NumericParameters.AFKCountdownSecs,
                 'AFK countdown',
                 'The time (in seconds) for a user to respond before the stream is ended after an AFK timeout.',
-                10 /*min*/,
-                180 /*max*/,
-                10 /*value*/,
+                10 /*min - 10 seconds*/,
+                600 /*max - 10 minutes*/,
+                settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.AFKCountdownSecs)
+                    ? settings[NumericParameters.AFKCountdownSecs]
+                    : 10 /*default value = 10 seconds*/,
                 useUrlParams
             )
         );


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:

This addresses an issue we've encountered where the AFK countdown and timeout delays are still too short.

## Solution

This PR bumps the max value supported for both AFK countdown and timeout.

## Documentation

N/A for this PR, the min/max values are not documented and documentation was added in the previous PR (see https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/247).

## Test Plan and Compatibility

We plan to internally test this with our fork to ensure we can set longer timeouts.

## Additional

We would really appreciate if this change could be backported to `UE5.3-1` (similar to this release - https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases/tag/UE5.3-1.0.6). The diff for that version is slightly different (it's actually simpler) and looks like this:

```diff
diff --git a/Frontend/library/src/Config/Config.ts b/Frontend/library/src/Config/Config.ts
index cd02bb9..7402e6f 100644
--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -472,7 +472,7 @@ export class Config {
                 'AFK timeout',
                 'The time (in seconds) it takes for the application to time out if AFK timeout is enabled.',
                 0 /*min*/,
-                600 /*max*/,
+                3600 /*max*/,
                 120 /*value*/,
                 useUrlParams
             )
@@ -485,7 +485,7 @@ export class Config {
                 'AFK countdown',
                 'The time (in seconds) for a user to respond before the stream is ended after an AFK timeout.',
                 10 /*min*/,
-                180 /*max*/,
+                600 /*max*/,
                 10 /*value*/,
                 useUrlParams
             )
```