### PR TITLE
Adding the ability to provide no min or max to a number setting.

### DIFF
--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -506,7 +506,7 @@ export class Config {
                 'AFK timeout',
                 'The time (in seconds) it takes for the application to time out if AFK timeout is enabled.',
                 0 /*min*/,
-                69 /*max*/,
+                undefined /*max*/,
                 settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.AFKTimeoutSecs)
                     ? settings[NumericParameters.AFKTimeoutSecs]
                     : 120 /*value*/,

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -506,7 +506,7 @@ export class Config {
                 'AFK timeout',
                 'The time (in seconds) it takes for the application to time out if AFK timeout is enabled.',
                 0 /*min*/,
-                undefined /*max*/,
+                null /*max*/,
                 settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.AFKTimeoutSecs)
                     ? settings[NumericParameters.AFKTimeoutSecs]
                     : 120 /*value*/,
@@ -521,7 +521,7 @@ export class Config {
                 'AFK countdown',
                 'The time (in seconds) for a user to respond before the stream is ended after an AFK timeout.',
                 10 /*min*/,
-                undefined /*max*/,
+                null /*max*/,
                 10 /*value*/,
                 useUrlParams
             )

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -506,7 +506,7 @@ export class Config {
                 'AFK timeout',
                 'The time (in seconds) it takes for the application to time out if AFK timeout is enabled.',
                 0 /*min*/,
-                600 /*max*/,
+                69 /*max*/,
                 settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.AFKTimeoutSecs)
                     ? settings[NumericParameters.AFKTimeoutSecs]
                     : 120 /*value*/,
@@ -521,7 +521,7 @@ export class Config {
                 'AFK countdown',
                 'The time (in seconds) for a user to respond before the stream is ended after an AFK timeout.',
                 10 /*min*/,
-                180 /*max*/,
+                undefined /*max*/,
                 10 /*value*/,
                 useUrlParams
             )

--- a/Frontend/library/src/Config/SettingNumber.ts
+++ b/Frontend/library/src/Config/SettingNumber.ts
@@ -7,8 +7,8 @@ import { SettingBase } from './SettingBase';
  * A number setting object with a text label. Min and max limit the range of allowed values.
  */
 export class SettingNumber<CustomIds extends string = NumericParametersIds> extends SettingBase {
-    _min: number | undefined;
-    _max: number | undefined;
+    _min: number | null;
+    _max: number | null;
 
     id: NumericParametersIds | CustomIds;
     onChangeEmit: (changedValue: number) => void;
@@ -17,8 +17,8 @@ export class SettingNumber<CustomIds extends string = NumericParametersIds> exte
         id: NumericParametersIds | CustomIds,
         label: string,
         description: string,
-        min: number | undefined,
-        max: number | undefined,
+        min: number | null,
+        max: number | null,
         defaultNumber: number,
         useUrlParams: boolean,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -65,11 +65,11 @@ export class SettingNumber<CustomIds extends string = NumericParametersIds> exte
      * @returns The clamped number.
      */
     public clamp(inNumber: number): number {
-        if (this._min == undefined && this._max == undefined) {
+        if (this._min == null && this._max == null) {
             return inNumber;
-        } else if (this._min == undefined) {
+        } else if (this._min == null) {
             return Math.min(this._max, inNumber);
-        } else if (this._max == undefined) {
+        } else if (this._max == null) {
             return Math.max(this._min, inNumber);
         } else {
             return Math.max(Math.min(this._max, inNumber), this._min);

--- a/Frontend/library/src/Config/SettingNumber.ts
+++ b/Frontend/library/src/Config/SettingNumber.ts
@@ -7,8 +7,8 @@ import { SettingBase } from './SettingBase';
  * A number setting object with a text label. Min and max limit the range of allowed values.
  */
 export class SettingNumber<CustomIds extends string = NumericParametersIds> extends SettingBase {
-    _min: number;
-    _max: number;
+    _min: number | undefined;
+    _max: number | undefined;
 
     id: NumericParametersIds | CustomIds;
     onChangeEmit: (changedValue: number) => void;
@@ -17,8 +17,8 @@ export class SettingNumber<CustomIds extends string = NumericParametersIds> exte
         id: NumericParametersIds | CustomIds,
         label: string,
         description: string,
-        min: number,
-        max: number,
+        min: number | undefined,
+        max: number | undefined,
         defaultNumber: number,
         useUrlParams: boolean,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -65,7 +65,15 @@ export class SettingNumber<CustomIds extends string = NumericParametersIds> exte
      * @returns The clamped number.
      */
     public clamp(inNumber: number): number {
-        return Math.max(Math.min(this._max, inNumber), this._min);
+        if (this._min == undefined && this._max == undefined) {
+            return inNumber;
+        } else if (this._min == undefined) {
+            return Math.min(this._max, inNumber);
+        } else if (this._max == undefined) {
+            return Math.max(this._min, inNumber);
+        } else {
+            return Math.max(Math.min(this._max, inNumber), this._min);
+        }
     }
 
     /**

--- a/Frontend/ui-library/src/Config/SettingUINumber.ts
+++ b/Frontend/ui-library/src/Config/SettingUINumber.ts
@@ -43,10 +43,10 @@ export class SettingUINumber<CustomIds extends string = NumericParametersIds> ex
         if (!this._spinner) {
             this._spinner = document.createElement('input');
             this._spinner.type = 'number';
-            if (this.setting.min != undefined) {
+            if (this.setting.min != null) {
                 this._spinner.min = this.setting.min.toString();
             }
-            if (this.setting.max != undefined) {
+            if (this.setting.max != null) {
                 this._spinner.max = this.setting.max.toString();
             }
             this._spinner.value = this.setting.number.toString();

--- a/Frontend/ui-library/src/Config/SettingUINumber.ts
+++ b/Frontend/ui-library/src/Config/SettingUINumber.ts
@@ -43,8 +43,12 @@ export class SettingUINumber<CustomIds extends string = NumericParametersIds> ex
         if (!this._spinner) {
             this._spinner = document.createElement('input');
             this._spinner.type = 'number';
-            this._spinner.min = this.setting.min.toString();
-            this._spinner.max = this.setting.max.toString();
+            if (this.setting.min != undefined) {
+                this._spinner.min = this.setting.min.toString();
+            }
+            if (this.setting.max != undefined) {
+                this._spinner.max = this.setting.max.toString();
+            }
             this._spinner.value = this.setting.number.toString();
             this._spinner.title = this.setting.description;
             this._spinner.classList.add('form-control');


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Sometimes we don't want to set a min or max value to a setting and the current solution is to just provide a large number which is kind of messy.

## Solution
I've added the ability to provide `undefined` for the min and max values which will remove the limiting to the min or max values. If min is undefined, there is no lower bound and if max is undefined there is no upper bound.

Also addresses #287 and removes the limit for the max AFK time and AFK countdown timer.