### PR TITLE
Fix unhandled error on client from SettingOption.ts

### DIFF
--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -76,7 +76,12 @@ export class SettingOption<CustomIds extends string = OptionParametersIds> exten
         // A user may not specify the full possible value so we instead use the closest match.
         // eg ?xxx=H264 would select 'H264 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f'
         if (!value || typeof value !== 'string' || value.trim() === '') {
-            Logger.Warning(`Invalid argument type for the selected codec, argument type: ${typeof value}, with value: ${value}`);
+            Logger.Warning(
+                `
+                Invalid argument type for the selected codec,
+                argument type: ${typeof value}, with value: ${value}
+                `
+            );
             return;
         }
 

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -74,18 +74,36 @@ export class SettingOption<CustomIds extends string = OptionParametersIds> exten
     public set selected(value: string) {
         // A user may not specify the full possible value so we instead use the closest match.
         // eg ?xxx=H264 would select 'H264 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f'
-        let filteredList = this.options.filter((option: string) => option.indexOf(value) !== -1);
-        if (filteredList.length) {
+        if (!value || typeof value !== 'string' || value.trim() === '') {
+            console.error('Invalid value for selected:', value);
+            return;
+        }
+    
+        let filteredList = this.options.filter(
+            (option: string) => {
+                return option && option.indexOf(value.split(' ')[0]) !== -1;
+            }
+        );
+    
+        if (filteredList.length > 0) {
             this.value = filteredList[0];
             return;
         }
-
-        // A user has specified a codec with a fmtp string but this codec + fmtp line isn't available.
-        // in that case, just use the codec
-        filteredList = this.options.filter((option: string) => option.indexOf(value.split(' ')[0]) !== -1);
-        if (filteredList.length) {
+    
+        // If no match is found, and value contains parameters, try matching only the codec
+        const valueCodec = value.split(' ')[0];
+        filteredList = this.options.filter(
+            (option: string) => {
+                return option && option.indexOf(valueCodec) !== -1;
+            }
+        );
+    
+        if (filteredList.length > 0) {
             this.value = filteredList[0];
             return;
         }
+    
+        // If still no match is found
+        console.warn('No matching option found for selected value:', value);
     }
 }

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -2,6 +2,7 @@
 
 import type { OptionParametersIds } from './Config';
 import { SettingBase } from './SettingBase';
+import { Logger } from '../Logger/Logger';
 
 /**
  * An Option setting object with a text label. Allows you to specify an array of options and select one of them.
@@ -75,12 +76,15 @@ export class SettingOption<CustomIds extends string = OptionParametersIds> exten
         // A user may not specify the full possible value so we instead use the closest match.
         // eg ?xxx=H264 would select 'H264 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f'
         if (!value || typeof value !== 'string' || value.trim() === '') {
-            console.error('Invalid value for selected:', value);
+            Logger.Warning(
+                Logger.GetStackTrace(),
+                `Invalid argument type for the selected codec, argument type: ${typeof value}, with value: ${value}`
+            );
             return;
         }
 
         let filteredList = this.options.filter((option: string) => {
-            return option && option.indexOf(value.split(' ')[0]) !== -1;
+            return option && value.split(" ")[0] !== undefined && option.indexOf(value.split(' ')[0]) !== -1;
         });
 
         if (filteredList.length > 0) {

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -2,7 +2,7 @@
 
 import type { OptionParametersIds } from './Config';
 import { SettingBase } from './SettingBase';
-import { Logger } from '../Logger/Logger';
+import { Logger } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.5';
 
 /**
  * An Option setting object with a text label. Allows you to specify an array of options and select one of them.

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -78,31 +78,27 @@ export class SettingOption<CustomIds extends string = OptionParametersIds> exten
             console.error('Invalid value for selected:', value);
             return;
         }
-    
-        let filteredList = this.options.filter(
-            (option: string) => {
-                return option && option.indexOf(value.split(' ')[0]) !== -1;
-            }
-        );
-    
+
+        let filteredList = this.options.filter((option: string) => {
+            return option && option.indexOf(value.split(' ')[0]) !== -1;
+        });
+
         if (filteredList.length > 0) {
             this.value = filteredList[0];
             return;
         }
-    
+
         // If no match is found, and value contains parameters, try matching only the codec
         const valueCodec = value.split(' ')[0];
-        filteredList = this.options.filter(
-            (option: string) => {
-                return option && option.indexOf(valueCodec) !== -1;
-            }
-        );
-    
+        filteredList = this.options.filter((option: string) => {
+            return option && option.indexOf(valueCodec) !== -1;
+        });
+
         if (filteredList.length > 0) {
             this.value = filteredList[0];
             return;
         }
-    
+
         // If still no match is found
         console.warn('No matching option found for selected value:', value);
     }

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -76,10 +76,7 @@ export class SettingOption<CustomIds extends string = OptionParametersIds> exten
         // A user may not specify the full possible value so we instead use the closest match.
         // eg ?xxx=H264 would select 'H264 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f'
         if (!value || typeof value !== 'string' || value.trim() === '') {
-            Logger.Warning(
-                Logger.GetStackTrace(),
-                `Invalid argument type for the selected codec, argument type: ${typeof value}, with value: ${value}`
-            );
+            Logger.Warning(`Invalid argument type for the selected codec, argument type: ${typeof value}, with value: ${value}`);
             return;
         }
 

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -86,7 +86,7 @@ export class SettingOption<CustomIds extends string = OptionParametersIds> exten
         }
 
         let filteredList = this.options.filter((option: string) => {
-            return option && value.split(" ")[0] !== undefined && option.indexOf(value.split(' ')[0]) !== -1;
+            return option && value.split(' ')[0] !== undefined && option.indexOf(value.split(' ')[0]) !== -1;
         });
 
         if (filteredList.length > 0) {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
I have been having unhandled errors in production and found this update solves the issue we were having originating from SettingOptions.ts:
![settingOptionsError](https://github.com/user-attachments/assets/ab47ca26-3478-4f7b-98d2-6a0ad4cf98f0)


## Solution
The was an issue with the options not being ready in time, I am not sure if this is the best way to solve the bug as it may be better to solve elsewhere in the codebase but this has fixed the issue for us and now I don't get anymore production errors, if someone else knows a better fix then go for it.

## Testing
I have been running this code in productions for weeks now and no more issues that were occurring previously at least every few days.
