### PR TITLE
Bringing back the functionality that prevents unidentified streamers showing up in the streamer list

### DIFF
--- a/Common/src/Messages/signalling_messages.ts
+++ b/Common/src/Messages/signalling_messages.ts
@@ -319,6 +319,12 @@ export interface offer {
      * @generated from protobuf field: optional bool sfu = 4;
      */
     sfu?: boolean;
+    /**
+     * Indicates that the streamer is multiplexing data channels
+     *
+     * @generated from protobuf field: optional bool multiplex = 5;
+     */
+    multiplex?: boolean;
 }
 /**
  * *
@@ -1387,7 +1393,8 @@ class offer$Type extends MessageType<offer> {
             { no: 1, name: "type", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "sdp", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "playerId", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
-            { no: 4, name: "sfu", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
+            { no: 4, name: "sfu", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 5, name: "multiplex", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<offer>): offer {
@@ -1415,6 +1422,9 @@ class offer$Type extends MessageType<offer> {
                 case /* optional bool sfu */ 4:
                     message.sfu = reader.bool();
                     break;
+                case /* optional bool multiplex */ 5:
+                    message.multiplex = reader.bool();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -1439,6 +1449,9 @@ class offer$Type extends MessageType<offer> {
         /* optional bool sfu = 4; */
         if (message.sfu !== undefined)
             writer.tag(4, WireType.Varint).bool(message.sfu);
+        /* optional bool multiplex = 5; */
+        if (message.multiplex !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.multiplex);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/Common/src/Protocol/SignallingProtocol.ts
+++ b/Common/src/Protocol/SignallingProtocol.ts
@@ -48,7 +48,8 @@ export class SignallingProtocol extends EventEmitter {
 
             // call the handlers
             transport.emit('message', msg); // emit this for listeners listening to any message
-            if (!this.emit(msg.type, msg)) { // emit this for listeners listening for specific messages
+            if (!this.emit(msg.type, msg)) {
+                // emit this for listeners listening for specific messages
                 // no listeners
                 this.emit('unhandled', msg);
             }

--- a/Common/src/Protocol/SignallingProtocol.ts
+++ b/Common/src/Protocol/SignallingProtocol.ts
@@ -48,7 +48,10 @@ export class SignallingProtocol extends EventEmitter {
 
             // call the handlers
             transport.emit('message', msg); // emit this for listeners listening to any message
-            this.emit(msg.type, msg); // emit this for listeners listening for specific messages
+            if (!this.emit(msg.type, msg)) { // emit this for listeners listening for specific messages
+                // no listeners
+                this.emit('unhandled', msg);
+            }
         };
     }
 

--- a/Signalling/src/PlayerConnection.ts
+++ b/Signalling/src/PlayerConnection.ts
@@ -116,6 +116,10 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
         this.protocol.on(Messages.dataChannelRequest.typeName, this.sendToStreamer.bind(this));
         this.protocol.on(Messages.peerDataChannelsReady.typeName, this.sendToStreamer.bind(this));
         this.protocol.on(Messages.layerPreference.typeName, this.sendToStreamer.bind(this));
+
+        this.protocol.on('unhandled', (message: BaseMessage) => {
+            Logger.warn(`Unhandled protocol message: ${JSON.stringify(message)}`);
+        });
     }
 
     private sendToStreamer(message: BaseMessage): void {
@@ -210,7 +214,9 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
 
     private onListStreamers(_message: Messages.listStreamers): void {
         const listMessage = MessageHelpers.createMessage(Messages.streamerList, {
-            ids: this.server.streamerRegistry.streamers.map((streamer) => streamer.streamerId)
+            ids: this.server.streamerRegistry.streamers
+                .filter((streamer) => streamer.streaming)
+                .map((streamer) => streamer.streamerId)
         });
         this.sendMessage(listMessage);
     }

--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -61,7 +61,7 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
         this.transport.on('close', this.onTransportClose.bind(this));
 
         this.registerMessageHandlers();
-                                        
+
         this.protocol.on('unhandled', (message: BaseMessage) => {
             Logger.warn(`Unhandled protocol message: ${JSON.stringify(message)}`);
         });

--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -61,6 +61,10 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
         this.transport.on('close', this.onTransportClose.bind(this));
 
         this.registerMessageHandlers();
+                                        
+        this.protocol.on('unhandled', (message: BaseMessage) => {
+            Logger.warn(`Unhandled protocol message: ${JSON.stringify(message)}`);
+        });
     }
 
     /**


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [x] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Streamers can show up in the streamer list before they've identified and started streaming.

## Solution
Added a filter to filter out streamers that aren't streaming.

Additionally regenerated the proto files.