### PR TITLE
Fix: SFU not being able reconnect once a streamer has disconnected

### DIFF
--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -145,6 +145,13 @@ function connectSignalling(server) {
 async function onStreamerList(msg) {
   let success = false;
 
+  // If we're reconnecting, this SFU id will be in the streamer list. We want to remove it 
+  // as we don't want to subscribe to ourself
+  const index = msg.ids.indexOf(config.SFUId);
+  if (index > -1) {
+    msg.ids.splice(index, 1);
+  }
+
   // subscribe to either the configured streamer, or if not configured, just grab the first id
   if (msg.ids.length > 0) {
     if (!!config.subscribeStreamerId && config.subscribeStreamerId.length != 0) {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [X] SFU

## Problem statement:
Once the SFU is connected to a streamer, it would fail to reconnect if the streamer was to be restarted.

## Solution
The cause of this problem is due to the SFU already being a registered "streamer" with the signalling server during reconnect. This could cause the SFU to re-subscribe to itself and get stuck with no streaming.