### PR TITLE
Remove redundant and rigid setting of signaling url in uiless.html

### DIFF
--- a/Frontend/implementations/typescript/src/uiless.ts
+++ b/Frontend/implementations/typescript/src/uiless.ts
@@ -11,7 +11,6 @@ document.body.onload = function() {
 		initialSettings: {
 			AutoPlayVideo: true,
 			AutoConnect: true,
-			ss: "ws://localhost:80",
 			StartVideoMuted: true,
 			WaitForStreamer: true,
 		}


### PR DESCRIPTION

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This PR fixes https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues/308 which identified an issue in uiless.html where the signaling url was being always set to localhost even when running over the public internet.

## Solution
This PR fixes this bug by removing the setting on the signaling url and letting the settings automatically set it correctly.

## Documentation
N/A

## Test Plan and Compatibility
I tested this by serving uiless.html on non-standard port, without this PR that would fail to connect, with this PR a successful stream was established.
