### PR TITLE
fix: change typo in unregister callbacks to remove event listeners

### DIFF
--- a/Frontend/library/src/Inputs/TouchController.ts
+++ b/Frontend/library/src/Inputs/TouchController.ts
@@ -46,9 +46,9 @@ export class TouchController implements IInputController {
     }
 
     unregister() {
-        this.videoElementParent.addEventListener('touchstart', this.onTouchStartListener);
-        this.videoElementParent.addEventListener('touchend', this.onTouchEndListener);
-        this.videoElementParent.addEventListener('touchmove', this.onTouchMoveListener);
+        this.videoElementParent.removeEventListener('touchstart', this.onTouchStartListener);
+        this.videoElementParent.removeEventListener('touchend', this.onTouchEndListener);
+        this.videoElementParent.removeEventListener('touchmove', this.onTouchMoveListener);
     }
 
     private rememberTouch(touch: Touch) {


### PR DESCRIPTION

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This PR targets the TouchControllers unregister function, which re-added the same event listeners instead of removing them.

## Solution
Changed from addEventListener to removeEventListener