### PR TITLE
Adding the compatibility quality min/max

### DIFF
--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -37,13 +37,19 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: printf "BODY_CHECK=%s\n" "$PR_BODY" >> $GITHUB_ENV
+        run: |
+          echo "BODY_CHECK<<EOF" >> $GITHUB_ENV
+          echo "$PR_BODY" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Check commit message for push event
         if: github.event_name == 'push'
         env:
           COMMIT: ${{ github.event.head_commit.message }}
-        run: printf "BODY_CHECK=%s\n" "$COMMIT" >> $GITHUB_ENV
+        run: |
+          echo "BODY_CHECK<<EOF" >> $GITHUB_ENV
+          echo "$COMMIT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Check commit message for bypass
         id: checkbypass

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 5  # This should be enough history to contain the commit that triggered the PR
 
-      - name: Check PR body for bypass-publish-check
+      - name: Grab PR body
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -42,7 +42,7 @@ jobs:
           echo "$PR_BODY" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Check commit message for push event
+      - name: Grab commit message for push event
         if: github.event_name == 'push'
         env:
           COMMIT: ${{ github.event.head_commit.message }}
@@ -51,7 +51,7 @@ jobs:
           echo "$COMMIT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Check commit message for bypass
+      - name: Check if the body to check contains the bypass tag
         id: checkbypass
         run: |
           if echo "$BODY_CHECK" | grep -q "#bypass-publish-check"; then

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           fetch-depth: 5  # This should be enough history to contain the commit that triggered the PR
 
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github.event.pull_request) }}
+        run: echo "$GITHUB_CONTEXT"
+
       - name: Check commit message for push event
         env:
           COMMIT: ${{ github.event.head_commit.message }}

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -34,12 +34,15 @@ jobs:
           fetch-depth: 5  # This should be enough history to contain the commit that triggered the PR
 
       - name: Check PR body for bypass-publish-check
+        if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           if echo "$PR_BODY" | grep -q "#bypass-publish-check"; then
+            echo "bypass=true"
             echo "bypass=true" >> $GITHUB_OUTPUT
           else
+            echo "bypass=false"
             echo "bypass=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -37,13 +37,13 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: echo "BODY_CHECK=\"$PR_BODY\"" >> $GITHUB_ENV
+        run: printf "BODY_CHECK=%s\n" "$PR_BODY" >> $GITHUB_ENV
 
       - name: Check commit message for push event
         if: github.event_name == 'push'
         env:
           COMMIT: ${{ github.event.head_commit.message }}
-        run: echo "BODY_CHECK=\"$COMMIT\"" >> $GITHUB_ENV
+        run: printf "BODY_CHECK=%s\n" "$COMMIT" >> $GITHUB_ENV
 
       - name: Check commit message for bypass
         id: checkbypass

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -33,40 +33,24 @@ jobs:
         with:
           fetch-depth: 5  # This should be enough history to contain the commit that triggered the PR
 
-      - name: Dump GitHub context
+      - name: Check PR body for bypass-publish-check
+        if: github.event_name == 'pull_request'
         env:
-          GITHUB_CONTEXT: ${{ toJson(github.event.pull_request) }}
-        run: echo "$GITHUB_CONTEXT"
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if echo "$PR_BODY" | grep -q "#bypass-publish-check"; then
+            echo "bypass=true" >> $GITHUB_OUTPUT
+          else
+            echo "bypass=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Check commit message for push event
+        if: github.event_name == 'push'
         env:
           COMMIT: ${{ github.event.head_commit.message }}
-        if: github.event_name == 'push'
         run: |
           echo "Commit message: ${{ env.COMMIT }}"
           echo "COMMIT=${{ env.COMMIT }}" >> $GITHUB_ENV
-
-      - name: Check commit message for pull request event
-        if: github.event_name == 'pull_request'
-        run: |
-          # Get the latest commit SHA for the pull request
-          COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
-          echo "Fetching commit message for PR commit: $COMMIT_SHA"
-          COMMIT_MESSAGE=$(git log -1 --pretty=%B "$COMMIT_SHA")
-          echo "Commit message: $COMMIT_MESSAGE"
-          echo "COMMIT=$COMMIT_MESSAGE" >> $GITHUB_ENV
-
-      - name: Check commit message for bypass
-        id: checkbypass
-        run: |
-          echo "$COMMIT"
-          if echo "$COMMIT" | grep -q "#bypass-publish-check"; then
-            echo "bypass=true" >> $GITHUB_OUTPUT
-            echo "bypass=true"
-          else
-            echo "bypass=false" >> $GITHUB_OUTPUT
-            echo "bypass=false"
-          fi
 
   build-using-public-deps:
       needs: check-if-bypass

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -37,22 +37,24 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          if echo "$PR_BODY" | grep -q "#bypass-publish-check"; then
-            echo "bypass=true"
-            echo "bypass=true" >> $GITHUB_OUTPUT
-          else
-            echo "bypass=false"
-            echo "bypass=false" >> $GITHUB_OUTPUT
-          fi
+        run: echo BODY_CHECK="$PR_BODY" >> $GITHUB_ENV
 
       - name: Check commit message for push event
         if: github.event_name == 'push'
         env:
           COMMIT: ${{ github.event.head_commit.message }}
+        run: echo BODY_CHECK="$COMMIT" >> $GITHUB_ENV
+
+      - name: Check commit message for bypass
+        id: checkbypass
         run: |
-          echo "Commit message: ${{ env.COMMIT }}"
-          echo "COMMIT=${{ env.COMMIT }}" >> $GITHUB_ENV
+          if echo "$BODY_CHECK" | grep -q "#bypass-publish-check"; then
+            echo "bypass=true" >> $GITHUB_OUTPUT
+            echo "bypass=true"
+          else
+            echo "bypass=false" >> $GITHUB_OUTPUT
+            echo "bypass=flase"
+          fi
 
   build-using-public-deps:
       needs: check-if-bypass

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -34,7 +34,6 @@ jobs:
           fetch-depth: 5  # This should be enough history to contain the commit that triggered the PR
 
       - name: Check PR body for bypass-publish-check
-        if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -37,13 +37,13 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: echo BODY_CHECK="$PR_BODY" >> $GITHUB_ENV
+        run: echo "BODY_CHECK=\"$PR_BODY\"" >> $GITHUB_ENV
 
       - name: Check commit message for push event
         if: github.event_name == 'push'
         env:
           COMMIT: ${{ github.event.head_commit.message }}
-        run: echo BODY_CHECK="$COMMIT" >> $GITHUB_ENV
+        run: echo "BODY_CHECK=\"$COMMIT\"" >> $GITHUB_ENV
 
       - name: Check commit message for bypass
         id: checkbypass

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -109,12 +109,12 @@ export type OptionIds = FlagsIds | NumericParametersIds | TextParametersIds | Op
 export type OptionKeys<T> = T extends FlagsIds
     ? boolean
     : T extends NumericParametersIds
-    ? number
-    : T extends TextParametersIds
-    ? string
-    : T extends OptionParametersIds
-    ? string
-    : never;
+      ? number
+      : T extends TextParametersIds
+        ? string
+        : T extends OptionParametersIds
+          ? string
+          : never;
 
 export type AllSettings = {
     [K in OptionIds]: OptionKeys<K>;
@@ -174,11 +174,11 @@ export class Config {
                 settings && Object.prototype.hasOwnProperty.call(settings, TextParameters.SignallingServerUrl)
                     ? settings[TextParameters.SignallingServerUrl]
                     : (location.protocol === 'https:' ? 'wss://' : 'ws://') +
-                    window.location.hostname +
-                    // for readability, we omit the port if it's 80
-                    (window.location.port === '80' || window.location.port === ''
-                        ? ''
-                        : `:${window.location.port}`),
+                      window.location.hostname +
+                      // for readability, we omit the port if it's 80
+                      (window.location.port === '80' || window.location.port === ''
+                          ? ''
+                          : `:${window.location.port}`),
                 useUrlParams
             )
         );
@@ -199,7 +199,7 @@ export class Config {
             )
         );
 
-        const getBrowserSupportedVideoCodecs = function(): Array<string> {
+        const getBrowserSupportedVideoCodecs = function (): Array<string> {
             const browserSupportedCodecs: Array<string> = [];
             // Try get the info needed from the RTCRtpReceiver. This is only available on chrome
             if (!RTCRtpReceiver.getCapabilities) {
@@ -224,7 +224,7 @@ export class Config {
             return browserSupportedCodecs;
         };
 
-        const getDefaultVideoCodec = function(): string {
+        const getDefaultVideoCodec = function (): string {
             const videoCodecs = getBrowserSupportedVideoCodecs();
             // If only one option, then select that.
             if (videoCodecs.length == 1) {
@@ -243,7 +243,7 @@ export class Config {
             return '';
         };
 
-        const matchSpecifiedCodecToClosestSupported = function(specifiedCodec: string): string {
+        const matchSpecifiedCodecToClosestSupported = function (specifiedCodec: string): string {
             const browserSupportedCodecs: Array<string> = getBrowserSupportedVideoCodecs();
 
             // Codec supplied in url param is an exact match for the browser codec.
@@ -589,7 +589,7 @@ export class Config {
                 0 /*min*/,
                 999 /*max*/,
                 settings &&
-                    Object.prototype.hasOwnProperty.call(settings, NumericParameters.MaxReconnectAttempts)
+                Object.prototype.hasOwnProperty.call(settings, NumericParameters.MaxReconnectAttempts)
                     ? settings[NumericParameters.MaxReconnectAttempts]
                     : 3 /*value*/,
                 useUrlParams
@@ -740,7 +740,7 @@ export class Config {
                 500 /*min*/,
                 900000 /*max*/,
                 settings &&
-                    Object.prototype.hasOwnProperty.call(settings, NumericParameters.StreamerAutoJoinInterval)
+                Object.prototype.hasOwnProperty.call(settings, NumericParameters.StreamerAutoJoinInterval)
                     ? settings[NumericParameters.StreamerAutoJoinInterval]
                     : 3000 /*value*/,
                 useUrlParams

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -50,6 +50,10 @@ export class NumericParameters {
     static AFKCountdownSecs = 'AFKCountdown' as const;
     static MinQP = 'MinQP' as const;
     static MaxQP = 'MaxQP' as const;
+    static MinQuality = 'MinQuality' as const;
+    static MaxQuality = 'MaxQuality' as const;
+    static CompatQualityMin = 'CompatQualityMin' as const;
+    static CompatQualityMax = 'CompatQualityMax' as const;
     static WebRTCFPS = 'WebRTCFPS' as const;
     static WebRTCMinBitrate = 'WebRTCMinBitrate' as const;
     static WebRTCMaxBitrate = 'WebRTCMaxBitrate' as const;
@@ -105,12 +109,12 @@ export type OptionIds = FlagsIds | NumericParametersIds | TextParametersIds | Op
 export type OptionKeys<T> = T extends FlagsIds
     ? boolean
     : T extends NumericParametersIds
-      ? number
-      : T extends TextParametersIds
-        ? string
-        : T extends OptionParametersIds
-          ? string
-          : never;
+    ? number
+    : T extends TextParametersIds
+    ? string
+    : T extends OptionParametersIds
+    ? string
+    : never;
 
 export type AllSettings = {
     [K in OptionIds]: OptionKeys<K>;
@@ -170,11 +174,11 @@ export class Config {
                 settings && Object.prototype.hasOwnProperty.call(settings, TextParameters.SignallingServerUrl)
                     ? settings[TextParameters.SignallingServerUrl]
                     : (location.protocol === 'https:' ? 'wss://' : 'ws://') +
-                      window.location.hostname +
-                      // for readability, we omit the port if it's 80
-                      (window.location.port === '80' || window.location.port === ''
-                          ? ''
-                          : `:${window.location.port}`),
+                    window.location.hostname +
+                    // for readability, we omit the port if it's 80
+                    (window.location.port === '80' || window.location.port === ''
+                        ? ''
+                        : `:${window.location.port}`),
                 useUrlParams
             )
         );
@@ -195,7 +199,7 @@ export class Config {
             )
         );
 
-        const getBrowserSupportedVideoCodecs = function (): Array<string> {
+        const getBrowserSupportedVideoCodecs = function(): Array<string> {
             const browserSupportedCodecs: Array<string> = [];
             // Try get the info needed from the RTCRtpReceiver. This is only available on chrome
             if (!RTCRtpReceiver.getCapabilities) {
@@ -220,7 +224,7 @@ export class Config {
             return browserSupportedCodecs;
         };
 
-        const getDefaultVideoCodec = function (): string {
+        const getDefaultVideoCodec = function(): string {
             const videoCodecs = getBrowserSupportedVideoCodecs();
             // If only one option, then select that.
             if (videoCodecs.length == 1) {
@@ -239,7 +243,7 @@ export class Config {
             return '';
         };
 
-        const matchSpecifiedCodecToClosestSupported = function (specifiedCodec: string): string {
+        const matchSpecifiedCodecToClosestSupported = function(specifiedCodec: string): string {
             const browserSupportedCodecs: Array<string> = getBrowserSupportedVideoCodecs();
 
             // Codec supplied in url param is an exact match for the browser codec.
@@ -585,7 +589,7 @@ export class Config {
                 0 /*min*/,
                 999 /*max*/,
                 settings &&
-                Object.prototype.hasOwnProperty.call(settings, NumericParameters.MaxReconnectAttempts)
+                    Object.prototype.hasOwnProperty.call(settings, NumericParameters.MaxReconnectAttempts)
                     ? settings[NumericParameters.MaxReconnectAttempts]
                     : 3 /*value*/,
                 useUrlParams
@@ -618,6 +622,66 @@ export class Config {
                 settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.MaxQP)
                     ? settings[NumericParameters.MaxQP]
                     : 51 /*value*/,
+                useUrlParams
+            )
+        );
+
+        this.numericParameters.set(
+            NumericParameters.MinQuality,
+            new SettingNumber(
+                NumericParameters.MinQuality,
+                'Min Quality',
+                'The lower bound for the quality factor of the encoder. 0 = Worst quality, 100 = Best quality.',
+                0 /*min*/,
+                100 /*max*/,
+                settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.MinQuality)
+                    ? settings[NumericParameters.MinQuality]
+                    : 0 /*value*/,
+                useUrlParams
+            )
+        );
+
+        this.numericParameters.set(
+            NumericParameters.MaxQuality,
+            new SettingNumber(
+                NumericParameters.MaxQuality,
+                'Max Quality',
+                'The upper bound for the quality factor of the encoder. 0 = Worst quality, 100 = Best quality.',
+                0 /*min*/,
+                100 /*max*/,
+                settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.MaxQuality)
+                    ? settings[NumericParameters.MaxQuality]
+                    : 100 /*value*/,
+                useUrlParams
+            )
+        );
+
+        this.numericParameters.set(
+            NumericParameters.CompatQualityMin,
+            new SettingNumber(
+                NumericParameters.CompatQualityMin,
+                'Min Quality',
+                'The lower bound for encoding quality. 0 = Worst, 100 = Best.',
+                0 /*min*/,
+                100 /*max*/,
+                settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.CompatQualityMin)
+                    ? settings[NumericParameters.CompatQualityMin]
+                    : 0 /*value*/,
+                useUrlParams
+            )
+        );
+
+        this.numericParameters.set(
+            NumericParameters.CompatQualityMax,
+            new SettingNumber(
+                NumericParameters.CompatQualityMax,
+                'Max Quality',
+                'The upper bound for encoding quality. 0 = Worst, 100 = Best.',
+                0 /*min*/,
+                100 /*max*/,
+                settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.CompatQualityMax)
+                    ? settings[NumericParameters.CompatQualityMax]
+                    : 100 /*value*/,
                 useUrlParams
             )
         );
@@ -676,7 +740,7 @@ export class Config {
                 500 /*min*/,
                 900000 /*max*/,
                 settings &&
-                Object.prototype.hasOwnProperty.call(settings, NumericParameters.StreamerAutoJoinInterval)
+                    Object.prototype.hasOwnProperty.call(settings, NumericParameters.StreamerAutoJoinInterval)
                     ? settings[NumericParameters.StreamerAutoJoinInterval]
                     : 3000 /*value*/,
                 useUrlParams

--- a/Frontend/library/src/DataChannel/InitialSettings.ts
+++ b/Frontend/library/src/DataChannel/InitialSettings.ts
@@ -40,6 +40,8 @@ export class EncoderSettings {
     MaxBitrate?: number;
     MinQP?: number;
     MaxQP?: number;
+    MinQuality?: number;
+    MaxQuality?: number;
     RateControl?: 'CBR' | 'VBR' | 'ConstQP';
     FillerData?: boolean;
     MultiPass?: 'DISABLED' | 'QUARTER' | 'FULL';

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -183,19 +183,52 @@ export class PixelStreaming {
             this._webRtcController.setGamePadInputEnabled(isEnabled);
         });
 
-        // encoder settings
+        // direct qp settings
         this.config._addOnNumericSettingChangedListener(NumericParameters.MinQP, (newValue: number) => {
             Logger.Info('--------  Sending MinQP  --------');
             this._webRtcController.sendEncoderMinQP(newValue);
             Logger.Info('-------------------------------------------');
+            const quality = Math.trunc(100 * (1 - newValue / 51));
+            this.config.setNumericSetting(NumericParameters.CompatQualityMax, quality);
         });
 
         this.config._addOnNumericSettingChangedListener(NumericParameters.MaxQP, (newValue: number) => {
-            Logger.Info('--------  Sending encoder settings  --------');
+            Logger.Info('--------  Sending MaxQP  --------');
+            this._webRtcController.sendEncoderMaxQP(newValue);
+            Logger.Info('-------------------------------------------');
+            const quality = Math.trunc(100 * (1 - newValue / 51));
+            this.config.setNumericSetting(NumericParameters.CompatQualityMin, quality);
+        });
+
+        // direct quality factor settings
+        this.config._addOnNumericSettingChangedListener(NumericParameters.MinQuality, (newValue: number) => {
+            Logger.Info('--------  Sending MinQuality  --------');
+            this._webRtcController.sendEncoderMinQuality(newValue);
+            Logger.Info('-------------------------------------------');
+            this.config.setNumericSetting(NumericParameters.CompatQualityMin, newValue);
+        });
+
+        this.config._addOnNumericSettingChangedListener(NumericParameters.MaxQuality, (newValue: number) => {
+            Logger.Info('--------  Sending MaxQuality  --------');
+            this._webRtcController.sendEncoderMaxQuality(newValue);
+            Logger.Info('-------------------------------------------');
+            this.config.setNumericSetting(NumericParameters.CompatQualityMax, newValue);
+        });
+
+        // new quality value that gets scaled to qp for legacy reasons
+        this.config._addOnNumericSettingChangedListener(NumericParameters.CompatQualityMin, (newValue: number) => {
+            newValue = 51 - (newValue / 100) * 51;
+            Logger.Info('--------  Sending MinQP from quality value  --------');
             this._webRtcController.sendEncoderMaxQP(newValue);
             Logger.Info('-------------------------------------------');
         });
 
+        this.config._addOnNumericSettingChangedListener(NumericParameters.CompatQualityMax, (newValue: number) => {
+            newValue = 51 - (newValue / 100) * 51;
+            Logger.Info('--------  Sending MaxQP from quality value  --------');
+            this._webRtcController.sendEncoderMinQP(newValue);
+            Logger.Info('-------------------------------------------');
+        });
         // WebRTC settings
         this.config._addOnNumericSettingChangedListener(
             NumericParameters.WebRTCMinBitrate,
@@ -531,20 +564,54 @@ export class PixelStreaming {
         const urlParams = new IURLSearchParams(window.location.search);
         Logger.Info(`using URL parameters ${useUrlParams}`);
         if (settings.EncoderSettings) {
-            this.config.setNumericSetting(
-                NumericParameters.MinQP,
-                // If a setting is set in the URL, make sure we respect that value as opposed to what the application sends us
-                useUrlParams && urlParams.has(NumericParameters.MinQP)
-                    ? Number.parseFloat(urlParams.get(NumericParameters.MinQP))
-                    : settings.EncoderSettings.MinQP
-            );
+            // here we should either get Min/MaxQP from PS1
+            // or Min/MaxQuality from PS2
+            // we only want to set one set or the other as they converge in CompatQualityMin/Max and
+            // we dont want to have them conflict with default values.
+            if (settings.EncoderSettings.MinQP) {
+                this.config.setNumericSetting(
+                    NumericParameters.MinQP,
+                    // If a setting is set in the URL, make sure we respect that value as opposed to what the application sends us
+                    useUrlParams && urlParams.has(NumericParameters.MinQP)
+                        ? Number.parseFloat(urlParams.get(NumericParameters.MinQP))
+                        : (settings.EncoderSettings.MinQP || 0)
+                );
 
-            this.config.setNumericSetting(
-                NumericParameters.MaxQP,
-                useUrlParams && urlParams.has(NumericParameters.MaxQP)
-                    ? Number.parseFloat(urlParams.get(NumericParameters.MaxQP))
-                    : settings.EncoderSettings.MaxQP
-            );
+                this.config.setNumericSetting(
+                    NumericParameters.MaxQP,
+                    useUrlParams && urlParams.has(NumericParameters.MaxQP)
+                        ? Number.parseFloat(urlParams.get(NumericParameters.MaxQP))
+                        : (settings.EncoderSettings.MaxQP || 51)
+                );
+            }
+
+            if (settings.EncoderSettings.MinQuality) {
+                this.config.setNumericSetting(
+                    NumericParameters.MinQuality,
+                    // If a setting is set in the URL, make sure we respect that value as opposed to what the application sends us
+                    useUrlParams && urlParams.has(NumericParameters.MinQuality)
+                        ? Number.parseFloat(urlParams.get(NumericParameters.MinQuality))
+                        : (settings.EncoderSettings.MinQuality || 0)
+                );
+
+                this.config.setNumericSetting(
+                    NumericParameters.MaxQuality,
+                    useUrlParams && urlParams.has(NumericParameters.MaxQuality)
+                        ? Number.parseFloat(urlParams.get(NumericParameters.MaxQuality))
+                        : (settings.EncoderSettings.MaxQuality || 100)
+                );
+            }
+
+            // these two are just used to converge quality and qp and behave slightly differently since they
+            // shouldnt exist in EncoderSettings
+            if (useUrlParams) {
+                if (urlParams.has(NumericParameters.CompatQualityMin)) {
+                    this.config.setNumericSetting(NumericParameters.CompatQualityMin, Number.parseFloat(urlParams.get(NumericParameters.CompatQualityMin)));
+                }
+                if (urlParams.has(NumericParameters.CompatQualityMax)) {
+                    this.config.setNumericSetting(NumericParameters.CompatQualityMax, Number.parseFloat(urlParams.get(NumericParameters.CompatQualityMax)));
+                }
+            }
         }
         if (settings.WebRTCSettings) {
             this.config.setNumericSetting(

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -216,19 +216,25 @@ export class PixelStreaming {
         });
 
         // new quality value that gets scaled to qp for legacy reasons
-        this.config._addOnNumericSettingChangedListener(NumericParameters.CompatQualityMin, (newValue: number) => {
-            newValue = 51 - (newValue / 100) * 51;
-            Logger.Info('--------  Sending MinQP from quality value  --------');
-            this._webRtcController.sendEncoderMaxQP(newValue);
-            Logger.Info('-------------------------------------------');
-        });
+        this.config._addOnNumericSettingChangedListener(
+            NumericParameters.CompatQualityMin,
+            (newValue: number) => {
+                newValue = 51 - (newValue / 100) * 51;
+                Logger.Info('--------  Sending MinQP from quality value  --------');
+                this._webRtcController.sendEncoderMaxQP(newValue);
+                Logger.Info('-------------------------------------------');
+            }
+        );
 
-        this.config._addOnNumericSettingChangedListener(NumericParameters.CompatQualityMax, (newValue: number) => {
-            newValue = 51 - (newValue / 100) * 51;
-            Logger.Info('--------  Sending MaxQP from quality value  --------');
-            this._webRtcController.sendEncoderMinQP(newValue);
-            Logger.Info('-------------------------------------------');
-        });
+        this.config._addOnNumericSettingChangedListener(
+            NumericParameters.CompatQualityMax,
+            (newValue: number) => {
+                newValue = 51 - (newValue / 100) * 51;
+                Logger.Info('--------  Sending MaxQP from quality value  --------');
+                this._webRtcController.sendEncoderMinQP(newValue);
+                Logger.Info('-------------------------------------------');
+            }
+        );
         // WebRTC settings
         this.config._addOnNumericSettingChangedListener(
             NumericParameters.WebRTCMinBitrate,
@@ -574,14 +580,14 @@ export class PixelStreaming {
                     // If a setting is set in the URL, make sure we respect that value as opposed to what the application sends us
                     useUrlParams && urlParams.has(NumericParameters.MinQP)
                         ? Number.parseFloat(urlParams.get(NumericParameters.MinQP))
-                        : (settings.EncoderSettings.MinQP || 0)
+                        : settings.EncoderSettings.MinQP || 0
                 );
 
                 this.config.setNumericSetting(
                     NumericParameters.MaxQP,
                     useUrlParams && urlParams.has(NumericParameters.MaxQP)
                         ? Number.parseFloat(urlParams.get(NumericParameters.MaxQP))
-                        : (settings.EncoderSettings.MaxQP || 51)
+                        : settings.EncoderSettings.MaxQP || 51
                 );
             }
 
@@ -591,14 +597,14 @@ export class PixelStreaming {
                     // If a setting is set in the URL, make sure we respect that value as opposed to what the application sends us
                     useUrlParams && urlParams.has(NumericParameters.MinQuality)
                         ? Number.parseFloat(urlParams.get(NumericParameters.MinQuality))
-                        : (settings.EncoderSettings.MinQuality || 0)
+                        : settings.EncoderSettings.MinQuality || 0
                 );
 
                 this.config.setNumericSetting(
                     NumericParameters.MaxQuality,
                     useUrlParams && urlParams.has(NumericParameters.MaxQuality)
                         ? Number.parseFloat(urlParams.get(NumericParameters.MaxQuality))
-                        : (settings.EncoderSettings.MaxQuality || 100)
+                        : settings.EncoderSettings.MaxQuality || 100
                 );
             }
 
@@ -606,10 +612,16 @@ export class PixelStreaming {
             // shouldnt exist in EncoderSettings
             if (useUrlParams) {
                 if (urlParams.has(NumericParameters.CompatQualityMin)) {
-                    this.config.setNumericSetting(NumericParameters.CompatQualityMin, Number.parseFloat(urlParams.get(NumericParameters.CompatQualityMin)));
+                    this.config.setNumericSetting(
+                        NumericParameters.CompatQualityMin,
+                        Number.parseFloat(urlParams.get(NumericParameters.CompatQualityMin))
+                    );
                 }
                 if (urlParams.has(NumericParameters.CompatQualityMax)) {
-                    this.config.setNumericSetting(NumericParameters.CompatQualityMax, Number.parseFloat(urlParams.get(NumericParameters.CompatQualityMax)));
+                    this.config.setNumericSetting(
+                        NumericParameters.CompatQualityMax,
+                        Number.parseFloat(urlParams.get(NumericParameters.CompatQualityMax))
+                    );
                 }
             }
         }

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1488,6 +1488,44 @@ export class WebRtcPlayerController {
     }
 
     /**
+     * Send the MinQuality encoder setting to the UE Instance.
+     * @param minQuality - The lower bound for quality when encoding
+     * valid values are (0-100) where:
+     * 0 = Worst quality.
+     * 100 = Best quality.
+     */
+    sendEncoderMinQuality(minQuality: number) {
+        Logger.Info(`MinQuality=${minQuality}\n`);
+
+        if (minQuality != null) {
+            this.streamMessageController.toStreamerHandlers.get('Command')([
+                JSON.stringify({
+                    'Encoder.MinQuality': minQuality
+                })
+            ]);
+        }
+    }
+
+    /**
+     * Send the MaxQuality encoder setting to the UE Instance.
+     * @param maxQuality - The upper bound for quality when encoding
+     * valid values are (0-100) where:
+     * 0 = Best quality.
+     * 100 = Worst quality.
+     */
+    sendEncoderMaxQuality(maxQuality: number) {
+        Logger.Info(`MaxQuality=${maxQuality}\n`);
+
+        if (maxQuality != null) {
+            this.streamMessageController.toStreamerHandlers.get('Command')([
+                JSON.stringify({
+                    'Encoder.MaxQuality': maxQuality
+                })
+            ]);
+        }
+    }
+
+    /**
      * Send the { WebRTC.MinBitrate: SomeNumber }} command to UE to set
      * the minimum bitrate that we allow WebRTC to use
      * (note setting this too high in poor networks can be problematic).

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1510,8 +1510,8 @@ export class WebRtcPlayerController {
      * Send the MaxQuality encoder setting to the UE Instance.
      * @param maxQuality - The upper bound for quality when encoding
      * valid values are (0-100) where:
-     * 0 = Best quality.
-     * 100 = Worst quality.
+     * 0 = Worst quality.
+     * 100 = Best quality.
      */
     sendEncoderMaxQuality(maxQuality: number) {
         Logger.Info(`MaxQuality=${maxQuality}\n`);

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -178,8 +178,8 @@ export class ConfigUI {
         /* Setup all encoder related settings under this section */
         const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, 'Encoder');
 
-        this.addSettingNumeric(encoderSettingsSection, this.numericParametersUi.get(NumericParameters.MinQP));
-        this.addSettingNumeric(encoderSettingsSection, this.numericParametersUi.get(NumericParameters.MaxQP));
+        this.addSettingNumeric(encoderSettingsSection, this.numericParametersUi.get(NumericParameters.CompatQualityMin));
+        this.addSettingNumeric(encoderSettingsSection, this.numericParametersUi.get(NumericParameters.CompatQualityMax));
 
         const preferredCodecOption = this.optionParametersUi.get(OptionParameters.PreferredCodec);
         this.addSettingOption(

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -178,8 +178,14 @@ export class ConfigUI {
         /* Setup all encoder related settings under this section */
         const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, 'Encoder');
 
-        this.addSettingNumeric(encoderSettingsSection, this.numericParametersUi.get(NumericParameters.CompatQualityMin));
-        this.addSettingNumeric(encoderSettingsSection, this.numericParametersUi.get(NumericParameters.CompatQualityMax));
+        this.addSettingNumeric(
+            encoderSettingsSection,
+            this.numericParametersUi.get(NumericParameters.CompatQualityMin)
+        );
+        this.addSettingNumeric(
+            encoderSettingsSection,
+            this.numericParametersUi.get(NumericParameters.CompatQualityMax)
+        );
 
         const preferredCodecOption = this.optionParametersUi.get(OptionParameters.PreferredCodec);
         this.addSettingOption(


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
We want to simplify the quality values exposed to the user to be pulled into line with PS2

## Solution
A new middle man config value called CompatQualityMin/Max that exposes values of 0-100 to the user but behind the scenes converts to 0-51 to send to the streamer. This is to allow PS1 to use it and PS2 to convert it to quality.
In order to support URL parameters that directly modify either QP or Quality values, the existing QP value pairs still remain and another pair for Quality have been added that will send the values directly to the streamer and its left up to the streamer to interpret. These values work with the new CompatQuality values to reflect the correct quality level in the UI.

#bypass-publish-check