### PR TITLE
Adding git tags to each publish action.

### DIFF
--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -2,7 +2,7 @@ name: Publish common lib
 on:
   workflow_dispatch:
   push:
-    branches: ['UE5.5']
+    # branches: ['UE5.5']
     paths: ['Common/package.json']
 
 env:
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    # if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -20,12 +20,24 @@ jobs:
         with:
           sparse-checkout: 'Common'
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Extract library version
+        id: get-version
+        outputs:
+          version: ${{ env.package_version }}
+        run: |
+          package_content=`cat Common/package.json`
+          echo "package_version=${{ fromJson($package_content).version }}" >> $GITHUB_ENV
+
+      - name: Check version
+        run: |
+          echo ${{ steps.get-version.outputs.version }}
+
+      # - uses: actions/setup-node@v4
+      #   with:
+      #     node-version: "${{ env.NODE_VERSION }}"
+      #     registry-url: 'https://registry.npmjs.org'
+      # - run: npm install
+      # - run: npm run build
+      # - run: npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -21,18 +21,21 @@ jobs:
           sparse-checkout: 'Common'
           sparse-checkout-cone-mode: false
         
-      - run: |
+      - id: set-var
+        run: |
           package_content=`cat package.json`
           package_content="${package_content//'%'/'%25'}"
           package_content="${package_content//$'\n'/'%0A'}"
           package_content="${package_content//$'\r'/'%0D'}"
-          echo "json=${{ fromJson(env.package_content).version }}"
-          # echo "json=$package_content" >> $GITHUB_ENV
+          echo "::set-output name=json::$package_content"
+
+      - run: |
+          echo "${{ fromJson(steps.set-var.outputs.json).version }}"
           
-      - name: Extract library version
-        id: get-version
-        run: |
-          echo "VERSION=${{ fromJson(env.json).version }}"
+      # - name: Extract library version
+      #   id: get-version
+      #   run: |
+      #     echo "VERSION=${{ fromJson(env.json).version }}"
 
       # - name: Check version
       #   run: |

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -22,7 +22,7 @@ jobs:
           sparse-checkout-cone-mode: false
         
       - run: |
-          echo "package_content=$(cat Common/package.json)"
+          echo "package_content=$(cat package.json)"
           
       - name: Extract library version
         id: get-version

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -30,8 +30,6 @@ jobs:
           echo "VERSION=$(echo $json)"
         env:
           json: ${{ env.json }}
-        outputs:
-          version: ${{ fromJson(env.json).version }}
 
       - name: Check version
         run: |

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -24,9 +24,6 @@ jobs:
       - id: set-var
         run: |
           package_content=`cat package.json`
-          package_content="${package_content//'%'/'%25'}"
-          package_content="${package_content//$'\n'/'%0A'}"
-          package_content="${package_content//$'\r'/'%0D'}"
           echo "json<<EOF" >> $GITHUB_OUTPUT
           echo $package_content >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -20,6 +20,16 @@ jobs:
         with:
           sparse-checkout: 'Common'
           sparse-checkout-cone-mode: false
+          
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         
       - id: get-package-json
         run: |
@@ -34,16 +44,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/lib-common-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              ref: 'refs/tags/lib-common-${{ fromJson(steps.get-package-json.outputs.json).version }}',
               sha: context.sha
             })
-          
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -20,13 +20,18 @@ jobs:
         with:
           sparse-checkout: 'Common'
           sparse-checkout-cone-mode: false
+        
+      - run: |
+          echo "package_content=$(cat Common/package.json)"
+          
       - name: Extract library version
         id: get-version
-        outputs:
-          version: ${{ env.package_version }}
         run: |
-          package_content=`cat Common/package.json`
-          echo "package_version=${{ fromJson(package_content).version }}" >> $GITHUB_ENV
+          echo "VERSION=$(echo $json)"
+        env:
+          json: ${{ env.json }}
+        outputs:
+          version: ${{ fromJson(env.json).version }}
 
       - name: Check version
         run: |

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -27,7 +27,9 @@ jobs:
           package_content="${package_content//'%'/'%25'}"
           package_content="${package_content//$'\n'/'%0A'}"
           package_content="${package_content//$'\r'/'%0D'}"
-          echo "json=$package_content" >> $GITHUB_OUTPUT
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
       - run: |
           echo "${{ fromJson(steps.set-var.outputs.json).version }}"

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -22,16 +22,20 @@ jobs:
           sparse-checkout-cone-mode: false
         
       - run: |
-          echo "package_content=$(cat package.json)" >> $GITHUB_ENV
+          package_content=`cat package.json`
+          package_content="${package_content//'%'/'%25'}"
+          package_content="${package_content//$'\n'/'%0A'}"
+          package_content="${package_content//$'\r'/'%0D'}"
+          echo "json=$package_content" >> $GITHUB_ENV
           
       - name: Extract library version
         id: get-version
         run: |
-          echo "VERSION=$(echo ${{ env.json }})"
+          echo "VERSION=${{ fromJson(env.json).version }}"
 
-      - name: Check version
-        run: |
-          echo ${{ steps.get-version.outputs.version }}
+      # - name: Check version
+      #   run: |
+      #     echo ${{ steps.get-version.outputs.version }}
 
       # - uses: actions/setup-node@v4
       #   with:

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -22,14 +22,12 @@ jobs:
           sparse-checkout-cone-mode: false
         
       - run: |
-          echo "package_content=$(cat package.json)"
+          echo "package_content=$(cat package.json)" >> $GITHUB_ENV
           
       - name: Extract library version
         id: get-version
         run: |
-          echo "VERSION=$(echo $json)"
-        env:
-          json: ${{ env.json }}
+          echo "VERSION=$(echo ${{ env.json }})"
 
       - name: Check version
         run: |

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -26,7 +26,7 @@ jobs:
           package_content="${package_content//'%'/'%25'}"
           package_content="${package_content//$'\n'/'%0A'}"
           package_content="${package_content//$'\r'/'%0D'}"
-          echo "json=$package_content"
+          echo "json=${{ fromJson($package_content).version }}"
           # echo "json=$package_content" >> $GITHUB_ENV
           
       - name: Extract library version

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -27,7 +27,7 @@ jobs:
           package_content="${package_content//'%'/'%25'}"
           package_content="${package_content//$'\n'/'%0A'}"
           package_content="${package_content//$'\r'/'%0D'}"
-          echo "::set-output name=json::$package_content"
+          echo "json=$package_content" >> $GITHUB_OUTPUT
 
       - run: |
           echo "${{ fromJson(steps.set-var.outputs.json).version }}"

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -26,7 +26,7 @@ jobs:
           version: ${{ env.package_version }}
         run: |
           package_content=`cat Common/package.json`
-          echo "package_version=${{ fromJson($package_content).version }}" >> $GITHUB_ENV
+          echo "package_version=${{ fromJson(package_content).version }}" >> $GITHUB_ENV
 
       - name: Check version
         run: |

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -21,15 +21,23 @@ jobs:
           sparse-checkout: 'Common'
           sparse-checkout-cone-mode: false
         
-      - id: set-var
+      - id: get-package-json
         run: |
           package_content=`cat package.json`
           echo "json<<EOF" >> $GITHUB_OUTPUT
           echo $package_content >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      - run: |
-          echo "${{ fromJson(steps.set-var.outputs.json).version }}"
+      - name: Create tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/common-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })
           
       # - name: Extract library version
       #   id: get-version

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -26,7 +26,8 @@ jobs:
           package_content="${package_content//'%'/'%25'}"
           package_content="${package_content//$'\n'/'%0A'}"
           package_content="${package_content//$'\r'/'%0D'}"
-          echo "json=$package_content" >> $GITHUB_ENV
+          echo "json=$package_content"
+          # echo "json=$package_content" >> $GITHUB_ENV
           
       - name: Extract library version
         id: get-version

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -26,7 +26,7 @@ jobs:
           package_content="${package_content//'%'/'%25'}"
           package_content="${package_content//$'\n'/'%0A'}"
           package_content="${package_content//$'\r'/'%0D'}"
-          echo "json=${{ fromJson($package_content).version }}"
+          echo "json=${{ fromJson(env.package_content).version }}"
           # echo "json=$package_content" >> $GITHUB_ENV
           
       - name: Extract library version

--- a/.github/workflows/publish-common-library-to-npm.yml
+++ b/.github/workflows/publish-common-library-to-npm.yml
@@ -2,7 +2,7 @@ name: Publish common lib
 on:
   workflow_dispatch:
   push:
-    # branches: ['UE5.5']
+    branches: ['UE5.5']
     paths: ['Common/package.json']
 
 env:
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    # if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,32 +28,22 @@ jobs:
           echo $package_content >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      - name: Create tag
-        uses: actions/github-script@v5
+      - uses: actions/github-script@v5
         with:
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/common-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              ref: 'refs/tags/lib-common-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
               sha: context.sha
             })
           
-      # - name: Extract library version
-      #   id: get-version
-      #   run: |
-      #     echo "VERSION=${{ fromJson(env.json).version }}"
-
-      # - name: Check version
-      #   run: |
-      #     echo ${{ steps.get-version.outputs.version }}
-
-      # - uses: actions/setup-node@v4
-      #   with:
-      #     node-version: "${{ env.NODE_VERSION }}"
-      #     registry-url: 'https://registry.npmjs.org'
-      # - run: npm install
-      # - run: npm run build
-      # - run: npm publish --access public
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -17,6 +17,24 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        
+      - id: get-package-json
+        run: |
+          package_content=`cat SignallingWebServer/package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/signalling-webserver-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })
+
       -
         name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -32,15 +32,7 @@ jobs:
           tags: 'pixelstreamingunofficial/pixel-streaming-signalling-server:5.5'
           push: true
           file: SignallingWebServer/Dockerfile
-      -
-        name: Build and push the SFU container image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          tags: 'pixelstreamingunofficial/pixel-streaming-sfu:5.5'
-          push: true
-          file: SFU/Dockerfile
-        
+
       - id: get-package-json
         run: |
           package_content=`cat SignallingWebServer/package.json`

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: ['UE5.5']
-    paths: ['SignallingWebServer/**']
+    paths: ['SignallingWebServer/package.json']
 
 jobs:
   signalling-server-image:

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -17,23 +17,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
-        
-      - id: get-package-json
-        run: |
-          package_content=`cat SignallingWebServer/package.json`
-          echo "json<<EOF" >> $GITHUB_OUTPUT
-          echo $package_content >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-      - uses: actions/github-script@v5
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/signalling-webserver-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
-              sha: context.sha
-            })
 
       -
         name: Login to DockerHub
@@ -57,4 +40,20 @@ jobs:
           tags: 'pixelstreamingunofficial/pixel-streaming-sfu:5.5'
           push: true
           file: SFU/Dockerfile
+        
+      - id: get-package-json
+        run: |
+          package_content=`cat SignallingWebServer/package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/signalling-webserver-${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })

--- a/.github/workflows/publish-library-to-npm.yml
+++ b/.github/workflows/publish-library-to-npm.yml
@@ -20,6 +20,16 @@ jobs:
         with:
             sparse-checkout: 'Frontend/library'
             sparse-checkout-cone-mode: false
+          
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - id: get-package-json
         run: |
@@ -34,16 +44,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/lib-frontend-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              ref: 'refs/tags/lib-frontend-${{ fromJson(steps.get-package-json.outputs.json).version }}',
               sha: context.sha
             })
-          
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-library-to-npm.yml
+++ b/.github/workflows/publish-library-to-npm.yml
@@ -20,6 +20,24 @@ jobs:
         with:
             sparse-checkout: 'Frontend/library'
             sparse-checkout-cone-mode: false
+
+      - id: get-package-json
+        run: |
+          package_content=`cat package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/lib-frontend-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })
+          
       - uses: actions/setup-node@v4
         with:
           node-version: "${{ env.NODE_VERSION }}"

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -19,23 +19,6 @@ jobs:
         with:
             sparse-checkout: 'SFU'
             sparse-checkout-cone-mode: false
-        
-      - id: get-package-json
-        run: |
-          package_content=`cat SFU/package.json`
-          echo "json<<EOF" >> $GITHUB_OUTPUT
-          echo $package_content >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-      - uses: actions/github-script@v5
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/sfu-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
-              sha: context.sha
-            })
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -50,4 +33,20 @@ jobs:
           tags: 'pixelstreamingunofficial/pixel-streaming-sfu:5.5'
           push: true
           file: SFU/Dockerfile
-          
+        
+      - id: get-package-json
+        run: |
+          package_content=`cat SFU/package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/sfu-${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: ['UE5.5']
-    paths: ['SFU/**']
+    paths: ['SFU/package.json']
 
 jobs:
   signalling-server-image:

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -19,6 +19,23 @@ jobs:
         with:
             sparse-checkout: 'SFU'
             sparse-checkout-cone-mode: false
+        
+      - id: get-package-json
+        run: |
+          package_content=`cat SFU/package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/sfu-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/publish-signalling-library-to-npm.yml
+++ b/.github/workflows/publish-signalling-library-to-npm.yml
@@ -20,6 +20,24 @@ jobs:
         with:
           sparse-checkout: 'Signalling'
           sparse-checkout-cone-mode: false
+        
+      - id: get-package-json
+        run: |
+          package_content=`cat Signalling/package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/lib-signalling-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })
+
       - uses: actions/setup-node@v4
         with:
           node-version: "${{ env.NODE_VERSION }}"

--- a/.github/workflows/publish-signalling-library-to-npm.yml
+++ b/.github/workflows/publish-signalling-library-to-npm.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           sparse-checkout: 'Signalling'
           sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install && npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         
       - id: get-package-json
         run: |
@@ -34,15 +43,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/lib-signalling-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              ref: 'refs/tags/lib-signalling-${{ fromJson(steps.get-package-json.outputs.json).version }}',
               sha: context.sha
             })
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install && npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-ui-library-to-npm.yml
+++ b/.github/workflows/publish-ui-library-to-npm.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           sparse-checkout: 'Frontend/ui-library'
           sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - id: get-package-json
         run: |
@@ -34,15 +43,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/lib-frontend-ui-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              ref: 'refs/tags/lib-frontend-ui-${{ fromJson(steps.get-package-json.outputs.json).version }}',
               sha: context.sha
             })
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-ui-library-to-npm.yml
+++ b/.github/workflows/publish-ui-library-to-npm.yml
@@ -20,6 +20,23 @@ jobs:
         with:
           sparse-checkout: 'Frontend/ui-library'
           sparse-checkout-cone-mode: false
+
+      - id: get-package-json
+        run: |
+          package_content=`cat package.json`
+          echo "json<<EOF" >> $GITHUB_OUTPUT
+          echo $package_content >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/lib-frontend-ui-v${{ fromJson(steps.get-package-json.outputs.json).version }}',
+              sha: context.sha
+            })
       - uses: actions/setup-node@v4
         with:
           node-version: "${{ env.NODE_VERSION }}"


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU
- [x] Other

Each component that is published will now use its package.json file/version number to create a tag at the point of publishing.

This should give us a nice foundation for Github releases of these packages with changelog generation in the future.
