### PR TITLE
Fix: Unnecessary warnings about unregistered message handlers

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -402,6 +402,12 @@ export class WebRtcPlayerController {
         );
         this.streamMessageController.registerMessageHandler(
             MessageDirection.FromStreamer,
+            'Multiplexed',
+            () => {
+                /* Do nothing as this message type is used only by the SFU */                
+        });
+        this.streamMessageController.registerMessageHandler(
+            MessageDirection.FromStreamer,
             'Protocol',
             (data: ArrayBuffer) => this.onProtocolMessage(data)
         );
@@ -627,6 +633,18 @@ export class WebRtcPlayerController {
             (data: Array<number | string>) =>
                 this.sendMessageController.sendMessageToStreamer('XRAnalog', data)
         );
+        this.streamMessageController.registerMessageHandler(
+            MessageDirection.ToStreamer,
+            'ChannelRelayStatus',
+            () => {
+                /* Do nothing as this message type is used only by the SFU */                
+        });
+        this.streamMessageController.registerMessageHandler(
+            MessageDirection.ToStreamer,
+            'Multiplexed',
+            () => {
+                /* Do nothing as this message type is used only by the SFU */                
+        });
     }
 
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -404,8 +404,9 @@ export class WebRtcPlayerController {
             MessageDirection.FromStreamer,
             'Multiplexed',
             () => {
-                /* Do nothing as this message type is used only by the SFU */                
-        });
+                /* Do nothing as this message type is used only by the SFU */
+            }
+        );
         this.streamMessageController.registerMessageHandler(
             MessageDirection.FromStreamer,
             'Protocol',
@@ -637,14 +638,16 @@ export class WebRtcPlayerController {
             MessageDirection.ToStreamer,
             'ChannelRelayStatus',
             () => {
-                /* Do nothing as this message type is used only by the SFU */                
-        });
+                /* Do nothing as this message type is used only by the SFU */
+            }
+        );
         this.streamMessageController.registerMessageHandler(
             MessageDirection.ToStreamer,
             'Multiplexed',
             () => {
-                /* Do nothing as this message type is used only by the SFU */                
-        });
+                /* Do nothing as this message type is used only by the SFU */
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Unreal Engine 5.5 added the PixelStreaming2 plugin which includes some new protocol messages:
- `ChannelRelayStatus`
- `Multiplexed`

Currently, the frontend throws warnings about unregistered handlers as these messages are for use with the SFU specifically.

## Solution
Adds default no-op handlers for the new messages.