### PR TITLE
Fixing erroneous import for Flags

### DIFF
--- a/Frontend/library/src/WebXR/WebXRController.ts
+++ b/Frontend/library/src/WebXR/WebXRController.ts
@@ -4,7 +4,7 @@ import { Logger } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.5';
 import { WebRtcPlayerController } from '../WebRtcPlayer/WebRtcPlayerController';
 import { XRGamepadController } from '../Inputs/XRGamepadController';
 import { XrFrameEvent } from '../Util/EventEmitter';
-import { Flags } from '../pixelstreamingfrontend';
+import { Flags } from '../Config/Config';
 
 export class WebXRController {
     private xrSession: XRSession;


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Fixes #363

## Solution
Updated the import to point to the correct export.
