### PR TITLE
fix byte incosistency

### DIFF
--- a/Frontend/library/src/Util/FileUtil.ts
+++ b/Frontend/library/src/Util/FileUtil.ts
@@ -61,7 +61,7 @@ export class FileUtil {
         // Extract the total size of the file (across all chunks)
         file.size = Math.ceil(
             new DataView(view.slice(1, 5).buffer).getInt32(0, true) /
-                16379 /* The maximum number of payload bits per message*/
+                (16 * 1024) /* The maximum number of payload bits per message*/
         );
 
         // Get the file part of the payload


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The pre-defined 16kB were defined as 16379, which is not correct.

## Solution
Either use the real number of 16kB (16384) or compute it on the fly with 16 * 1024 (as done below when calculating the transferBitrate)

I recently implemented a screenshot feature in our UI that requests an image from the engine. This image is transferred using your "FreezeFrame" functionality. We can adjust our request by passing a desired width and height, which can sometimes result in missing bytes due to an incorrect calculation of the chunks to receive.
