### PR TITLE
Add: Functionality to disable UI on a per section basis

### DIFF
--- a/Frontend/implementations/typescript/src/player.ts
+++ b/Frontend/implementations/typescript/src/player.ts
@@ -22,7 +22,30 @@ document.body.onload = function() {
 
 	const application = new Application({
 		stream,
-		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode)
+		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode),
+		settingsPanelConfig: {
+			isEnabled: true,
+			settingVisibility: {
+			  StreamerId: false,
+			  ss: false,
+			  TimeoutIfIdle: false,
+			  ForceTURN: false,
+			  LightMode: false,
+			  UseMic: false,
+			  MatchViewportRes: false,
+			  HoveringMouse: false,
+			  AFKTimeout: false,
+			  AFKCountdown: false,
+			  MaxReconnectAttempts: false,
+			  StartVideoMuted: false
+			},
+			sectionVisibility: {
+			  Encoder: false,
+			  WebRTC: false,
+			  UI: false,
+			  Input: false
+			}
+		  }
 	});
 	document.body.appendChild(application.rootElement);
 

--- a/Frontend/implementations/typescript/src/player.ts
+++ b/Frontend/implementations/typescript/src/player.ts
@@ -22,30 +22,7 @@ document.body.onload = function() {
 
 	const application = new Application({
 		stream,
-		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode),
-		settingsPanelConfig: {
-			isEnabled: true,
-			settingVisibility: {
-			  StreamerId: false,
-			  ss: false,
-			  TimeoutIfIdle: false,
-			  ForceTURN: false,
-			  LightMode: false,
-			  UseMic: false,
-			  MatchViewportRes: false,
-			  HoveringMouse: false,
-			  AFKTimeout: false,
-			  AFKCountdown: false,
-			  MaxReconnectAttempts: false,
-			  StartVideoMuted: false
-			},
-			sectionVisibility: {
-			  Encoder: false,
-			  WebRTC: false,
-			  UI: false,
-			  Input: false
-			}
-		  }
+		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode)
 	});
 	document.body.appendChild(application.rootElement);
 

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -10,6 +10,7 @@ import {
     Messages,
     DataChannelLatencyTestResult,
     OptionParameters,
+    TextParameters,
     SettingsChangedEvent
 } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
 import { OverlayBase } from '../Overlay/BaseOverlay';
@@ -33,6 +34,7 @@ import {
     isPanelEnabled,
     UIElementConfig,
     SettingsPanelConfiguration,
+    StatsPanelConfiguration,
     ExtraFlags
 } from '../UI/UIConfigurationTypes';
 import { FullScreenIconBase, FullScreenIconExternal } from '../UI/FullscreenIcon';
@@ -60,7 +62,7 @@ export interface UIOptions {
     settingsPanelConfig?: SettingsPanelConfiguration;
     /** By default, a stats panel and associate visibility toggle button will be made.
      * If needed, this behaviour can be configured. */
-    statsPanelConfig?: PanelConfiguration;
+    statsPanelConfig?: StatsPanelConfiguration;
     /** If needed, the full screen button can be external or disabled. */
     fullScreenControlsConfig?: UIElementConfig;
     /** If needed, XR button can be external or disabled. */
@@ -115,7 +117,7 @@ export class Application {
 
         if (isPanelEnabled(options.statsPanelConfig)) {
             // Add stats panel
-            this.statsPanel = new StatsPanel();
+            this.statsPanel = new StatsPanel(options.statsPanelConfig);
             this.uiFeaturesElement.appendChild(this.statsPanel.rootElement);
         }
 

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -10,7 +10,6 @@ import {
     Messages,
     DataChannelLatencyTestResult,
     OptionParameters,
-    TextParameters,
     SettingsChangedEvent
 } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
 import { OverlayBase } from '../Overlay/BaseOverlay';
@@ -30,7 +29,6 @@ import { VideoQpIndicator } from '../UI/VideoQpIndicator';
 import { ConfigUI } from '../Config/ConfigUI';
 import {
     UIElementCreationMode,
-    PanelConfiguration,
     isPanelEnabled,
     UIElementConfig,
     SettingsPanelConfiguration,

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -143,8 +143,6 @@ export class ConfigUI {
                     psSettingsSection,
                     this.optionParametersUi.get(OptionParameters.StreamerId)
                 );
-            if (isSettingEnabled(settingsConfig, TextParameters.PlayerId))
-                this.addSettingText(psSettingsSection, this.textParametersUi.get(TextParameters.PlayerId));
             if (isSettingEnabled(settingsConfig, Flags.AutoConnect))
                 this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AutoConnect));
             if (isSettingEnabled(settingsConfig, Flags.AutoPlayVideo))

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -130,7 +130,7 @@ export class ConfigUI {
     populateSettingsElement(settingsElem: HTMLElement, settingsConfig: SettingsPanelConfiguration): void {
         if (isSectionEnabled(settingsConfig, Sections.PixelStreaming)) {
             /* Setup all Pixel Streaming specific settings */
-            const psSettingsSection = this.buildSectionWithHeading(settingsElem, 'Pixel Streaming');
+            const psSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.PixelStreaming);
 
             // make settings show up in DOM
             if (isSettingEnabled(settingsConfig, TextParameters.SignallingServerUrl))
@@ -189,7 +189,7 @@ export class ConfigUI {
 
         if (isSectionEnabled(settingsConfig, Sections.UI)) {
             /* Setup all view/ui related settings under this section */
-            const viewSettingsSection = this.buildSectionWithHeading(settingsElem, 'UI');
+            const viewSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.UI);
             if (isSettingEnabled(settingsConfig, Flags.MatchViewportResolution))
                 this.addSettingFlag(viewSettingsSection, this.flagsUi.get(Flags.MatchViewportResolution));
 
@@ -202,7 +202,7 @@ export class ConfigUI {
 
         if (isSectionEnabled(settingsConfig, Sections.Input)) {
             /* Setup all encoder related settings under this section */
-            const inputSettingsSection = this.buildSectionWithHeading(settingsElem, 'Input');
+            const inputSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.Input);
 
             if (isSettingEnabled(settingsConfig, Flags.KeyboardInput))
                 this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.KeyboardInput));
@@ -225,7 +225,7 @@ export class ConfigUI {
 
         if (isSectionEnabled(settingsConfig, Sections.Encoder)) {
             /* Setup all encoder related settings under this section */
-            const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, 'Encoder');
+            const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.Encoder);
 
             if (isSettingEnabled(settingsConfig, NumericParameters.CompatQualityMin))
                 this.addSettingNumeric(
@@ -262,7 +262,7 @@ export class ConfigUI {
 
         if (isSectionEnabled(settingsConfig, Sections.WebRTC)) {
             /* Setup all webrtc related settings under this section */
-            const webrtcSettingsSection = this.buildSectionWithHeading(settingsElem, 'WebRTC');
+            const webrtcSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.WebRTC);
 
             if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCFPS))
                 this.addSettingNumeric(

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -30,8 +30,10 @@ import {
     ExtraFlags,
     ExtraFlagsIds,
     FlagsIdsExtended,
+    isSectionEnabled,
     isSettingEnabled,
     OptionIdsExtended,
+    Sections,
     SettingsPanelConfiguration
 } from '../UI/UIConfigurationTypes';
 
@@ -126,148 +128,160 @@ export class ConfigUI {
      * @param settingsElem - - The element that contains all the individual settings sections, flags, and so on.
      */
     populateSettingsElement(settingsElem: HTMLElement, settingsConfig: SettingsPanelConfiguration): void {
-        /* Setup all Pixel Streaming specific settings */
-        const psSettingsSection = this.buildSectionWithHeading(settingsElem, 'Pixel Streaming');
+        if (isSectionEnabled(settingsConfig, Sections.PixelStreaming)) {
+            /* Setup all Pixel Streaming specific settings */
+            const psSettingsSection = this.buildSectionWithHeading(settingsElem, 'Pixel Streaming');
 
-        // make settings show up in DOM
-        if (isSettingEnabled(settingsConfig, TextParameters.SignallingServerUrl))
-            this.addSettingText(
-                psSettingsSection,
-                this.textParametersUi.get(TextParameters.SignallingServerUrl)
-            );
-        if (isSettingEnabled(settingsConfig, OptionParameters.StreamerId))
-            this.addSettingOption(
-                psSettingsSection,
-                this.optionParametersUi.get(OptionParameters.StreamerId)
-            );
-        if (isSettingEnabled(settingsConfig, Flags.AutoConnect))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AutoConnect));
-        if (isSettingEnabled(settingsConfig, Flags.AutoPlayVideo))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AutoPlayVideo));
-        if (isSettingEnabled(settingsConfig, Flags.UseMic))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.UseMic));
-        if (isSettingEnabled(settingsConfig, Flags.UseCamera))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.UseCamera));
-        if (isSettingEnabled(settingsConfig, Flags.StartVideoMuted))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.StartVideoMuted));
-        if (isSettingEnabled(settingsConfig, Flags.IsQualityController))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.IsQualityController));
-        if (isSettingEnabled(settingsConfig, Flags.ForceMonoAudio))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.ForceMonoAudio));
-        if (isSettingEnabled(settingsConfig, Flags.ForceTURN))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.ForceTURN));
-        if (isSettingEnabled(settingsConfig, Flags.SuppressBrowserKeys))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.SuppressBrowserKeys));
-        if (isSettingEnabled(settingsConfig, Flags.AFKDetection))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AFKDetection));
-        if (isSettingEnabled(settingsConfig, Flags.WaitForStreamer))
-            this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.WaitForStreamer));
-        if (isSettingEnabled(settingsConfig, NumericParameters.AFKTimeoutSecs))
-            this.addSettingNumeric(
-                psSettingsSection,
-                this.numericParametersUi.get(NumericParameters.AFKTimeoutSecs)
-            );
-        if (isSettingEnabled(settingsConfig, NumericParameters.AFKCountdownSecs))
-            this.addSettingNumeric(
-                psSettingsSection,
-                this.numericParametersUi.get(NumericParameters.AFKCountdownSecs)
-            );
-        if (isSettingEnabled(settingsConfig, NumericParameters.MaxReconnectAttempts))
-            this.addSettingNumeric(
-                psSettingsSection,
-                this.numericParametersUi.get(NumericParameters.MaxReconnectAttempts)
-            );
-        if (isSettingEnabled(settingsConfig, NumericParameters.StreamerAutoJoinInterval))
-            this.addSettingNumeric(
-                psSettingsSection,
-                this.numericParametersUi.get(NumericParameters.StreamerAutoJoinInterval)
-            );
-
-        /* Setup all view/ui related settings under this section */
-        const viewSettingsSection = this.buildSectionWithHeading(settingsElem, 'UI');
-        if (isSettingEnabled(settingsConfig, Flags.MatchViewportResolution))
-            this.addSettingFlag(viewSettingsSection, this.flagsUi.get(Flags.MatchViewportResolution));
-
-        if (isSettingEnabled(settingsConfig, Flags.HoveringMouseMode))
-            this.addSettingFlag(viewSettingsSection, this.flagsUi.get(Flags.HoveringMouseMode));
-
-        if (isSettingEnabled(settingsConfig, ExtraFlags.LightMode))
-            this.addSettingFlag(viewSettingsSection, this.flagsUi.get(ExtraFlags.LightMode));
-
-        /* Setup all encoder related settings under this section */
-        const inputSettingsSection = this.buildSectionWithHeading(settingsElem, 'Input');
-
-        if (isSettingEnabled(settingsConfig, Flags.KeyboardInput))
-            this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.KeyboardInput));
-
-        if (isSettingEnabled(settingsConfig, Flags.MouseInput))
-            this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.MouseInput));
-
-        if (isSettingEnabled(settingsConfig, Flags.FakeMouseWithTouches))
-            this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.FakeMouseWithTouches));
-
-        if (isSettingEnabled(settingsConfig, Flags.TouchInput))
-            this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.TouchInput));
-
-        if (isSettingEnabled(settingsConfig, Flags.GamepadInput))
-            this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.GamepadInput));
-
-        if (isSettingEnabled(settingsConfig, Flags.XRControllerInput))
-            this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.XRControllerInput));
-
-        /* Setup all encoder related settings under this section */
-        const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, 'Encoder');
-
-        if (isSettingEnabled(settingsConfig, NumericParameters.CompatQualityMin))
-            this.addSettingNumeric(
-                encoderSettingsSection,
-                this.numericParametersUi.get(NumericParameters.CompatQualityMin)
-            );
-        if (isSettingEnabled(settingsConfig, NumericParameters.CompatQualityMax))
-            this.addSettingNumeric(
-                encoderSettingsSection,
-                this.numericParametersUi.get(NumericParameters.CompatQualityMax)
-            );
-
-        const preferredCodecOption = this.optionParametersUi.get(OptionParameters.PreferredCodec);
-        if (isSettingEnabled(settingsConfig, OptionParameters.PreferredCodec))
-            this.addSettingOption(
-                encoderSettingsSection,
-                this.optionParametersUi.get(OptionParameters.PreferredCodec)
-            );
-        if (
-            preferredCodecOption &&
-            [...preferredCodecOption.selector.options]
-                .map((o) => o.value)
-                .includes('Only available on Chrome')
-        ) {
-            preferredCodecOption.disable();
+            // make settings show up in DOM
+            if (isSettingEnabled(settingsConfig, TextParameters.SignallingServerUrl))
+                this.addSettingText(
+                    psSettingsSection,
+                    this.textParametersUi.get(TextParameters.SignallingServerUrl)
+                );
+            if (isSettingEnabled(settingsConfig, OptionParameters.StreamerId))
+                this.addSettingOption(
+                    psSettingsSection,
+                    this.optionParametersUi.get(OptionParameters.StreamerId)
+                );
+            if (isSettingEnabled(settingsConfig, TextParameters.PlayerId))
+                this.addSettingText(psSettingsSection, this.textParametersUi.get(TextParameters.PlayerId));
+            if (isSettingEnabled(settingsConfig, Flags.AutoConnect))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AutoConnect));
+            if (isSettingEnabled(settingsConfig, Flags.AutoPlayVideo))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AutoPlayVideo));
+            if (isSettingEnabled(settingsConfig, Flags.UseMic))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.UseMic));
+            if (isSettingEnabled(settingsConfig, Flags.UseCamera))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.UseCamera));
+            if (isSettingEnabled(settingsConfig, Flags.StartVideoMuted))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.StartVideoMuted));
+            if (isSettingEnabled(settingsConfig, Flags.IsQualityController))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.IsQualityController));
+            if (isSettingEnabled(settingsConfig, Flags.ForceMonoAudio))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.ForceMonoAudio));
+            if (isSettingEnabled(settingsConfig, Flags.ForceTURN))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.ForceTURN));
+            if (isSettingEnabled(settingsConfig, Flags.SuppressBrowserKeys))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.SuppressBrowserKeys));
+            if (isSettingEnabled(settingsConfig, Flags.AFKDetection))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.AFKDetection));
+            if (isSettingEnabled(settingsConfig, Flags.WaitForStreamer))
+                this.addSettingFlag(psSettingsSection, this.flagsUi.get(Flags.WaitForStreamer));
+            if (isSettingEnabled(settingsConfig, NumericParameters.AFKTimeoutSecs))
+                this.addSettingNumeric(
+                    psSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.AFKTimeoutSecs)
+                );
+            if (isSettingEnabled(settingsConfig, NumericParameters.AFKCountdownSecs))
+                this.addSettingNumeric(
+                    psSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.AFKCountdownSecs)
+                );
+            if (isSettingEnabled(settingsConfig, NumericParameters.MaxReconnectAttempts))
+                this.addSettingNumeric(
+                    psSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.MaxReconnectAttempts)
+                );
+            if (isSettingEnabled(settingsConfig, NumericParameters.StreamerAutoJoinInterval))
+                this.addSettingNumeric(
+                    psSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.StreamerAutoJoinInterval)
+                );
         }
 
-        if (isSettingEnabled(settingsConfig, OptionParameters.PreferredQuality))
-            this.addSettingOption(
-                encoderSettingsSection,
-                this.optionParametersUi.get(OptionParameters.PreferredQuality)
-            );
+        if (isSectionEnabled(settingsConfig, Sections.UI)) {
+            /* Setup all view/ui related settings under this section */
+            const viewSettingsSection = this.buildSectionWithHeading(settingsElem, 'UI');
+            if (isSettingEnabled(settingsConfig, Flags.MatchViewportResolution))
+                this.addSettingFlag(viewSettingsSection, this.flagsUi.get(Flags.MatchViewportResolution));
 
-        /* Setup all webrtc related settings under this section */
-        const webrtcSettingsSection = this.buildSectionWithHeading(settingsElem, 'WebRTC');
+            if (isSettingEnabled(settingsConfig, Flags.HoveringMouseMode))
+                this.addSettingFlag(viewSettingsSection, this.flagsUi.get(Flags.HoveringMouseMode));
 
-        if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCFPS))
-            this.addSettingNumeric(
-                webrtcSettingsSection,
-                this.numericParametersUi.get(NumericParameters.WebRTCFPS)
-            );
-        if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCMinBitrate))
-            this.addSettingNumeric(
-                webrtcSettingsSection,
-                this.numericParametersUi.get(NumericParameters.WebRTCMinBitrate)
-            );
-        if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCMaxBitrate))
-            this.addSettingNumeric(
-                webrtcSettingsSection,
-                this.numericParametersUi.get(NumericParameters.WebRTCMaxBitrate)
-            );
+            if (isSettingEnabled(settingsConfig, ExtraFlags.LightMode))
+                this.addSettingFlag(viewSettingsSection, this.flagsUi.get(ExtraFlags.LightMode));
+        }
+
+        if (isSectionEnabled(settingsConfig, Sections.Input)) {
+            /* Setup all encoder related settings under this section */
+            const inputSettingsSection = this.buildSectionWithHeading(settingsElem, 'Input');
+
+            if (isSettingEnabled(settingsConfig, Flags.KeyboardInput))
+                this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.KeyboardInput));
+
+            if (isSettingEnabled(settingsConfig, Flags.MouseInput))
+                this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.MouseInput));
+
+            if (isSettingEnabled(settingsConfig, Flags.FakeMouseWithTouches))
+                this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.FakeMouseWithTouches));
+
+            if (isSettingEnabled(settingsConfig, Flags.TouchInput))
+                this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.TouchInput));
+
+            if (isSettingEnabled(settingsConfig, Flags.GamepadInput))
+                this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.GamepadInput));
+
+            if (isSettingEnabled(settingsConfig, Flags.XRControllerInput))
+                this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.XRControllerInput));
+        }
+
+        if (isSectionEnabled(settingsConfig, Sections.Encoder)) {
+            /* Setup all encoder related settings under this section */
+            const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, 'Encoder');
+
+            if (isSettingEnabled(settingsConfig, NumericParameters.CompatQualityMin))
+                this.addSettingNumeric(
+                    encoderSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.CompatQualityMin)
+                );
+            if (isSettingEnabled(settingsConfig, NumericParameters.CompatQualityMax))
+                this.addSettingNumeric(
+                    encoderSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.CompatQualityMax)
+                );
+
+            const preferredCodecOption = this.optionParametersUi.get(OptionParameters.PreferredCodec);
+            if (isSettingEnabled(settingsConfig, OptionParameters.PreferredCodec))
+                this.addSettingOption(
+                    encoderSettingsSection,
+                    this.optionParametersUi.get(OptionParameters.PreferredCodec)
+                );
+            if (
+                preferredCodecOption &&
+                [...preferredCodecOption.selector.options]
+                    .map((o) => o.value)
+                    .includes('Only available on Chrome')
+            ) {
+                preferredCodecOption.disable();
+            }
+
+            if (isSettingEnabled(settingsConfig, OptionParameters.PreferredQuality))
+                this.addSettingOption(
+                    encoderSettingsSection,
+                    this.optionParametersUi.get(OptionParameters.PreferredQuality)
+                );
+        }
+
+        if (isSectionEnabled(settingsConfig, Sections.WebRTC)) {
+            /* Setup all webrtc related settings under this section */
+            const webrtcSettingsSection = this.buildSectionWithHeading(settingsElem, 'WebRTC');
+
+            if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCFPS))
+                this.addSettingNumeric(
+                    webrtcSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.WebRTCFPS)
+                );
+            if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCMinBitrate))
+                this.addSettingNumeric(
+                    webrtcSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.WebRTCMinBitrate)
+                );
+            if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCMaxBitrate))
+                this.addSettingNumeric(
+                    webrtcSettingsSection,
+                    this.numericParametersUi.get(NumericParameters.WebRTCMaxBitrate)
+                );
+        }
     }
 
     /**

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -33,7 +33,7 @@ import {
     isSectionEnabled,
     isSettingEnabled,
     OptionIdsExtended,
-    Sections,
+    SettingsSections,
     SettingsPanelConfiguration
 } from '../UI/UIConfigurationTypes';
 
@@ -128,9 +128,12 @@ export class ConfigUI {
      * @param settingsElem - - The element that contains all the individual settings sections, flags, and so on.
      */
     populateSettingsElement(settingsElem: HTMLElement, settingsConfig: SettingsPanelConfiguration): void {
-        if (isSectionEnabled(settingsConfig, Sections.PixelStreaming)) {
+        if (isSectionEnabled(settingsConfig, SettingsSections.PixelStreaming)) {
             /* Setup all Pixel Streaming specific settings */
-            const psSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.PixelStreaming);
+            const psSettingsSection = this.buildSectionWithHeading(
+                settingsElem,
+                SettingsSections.PixelStreaming
+            );
 
             // make settings show up in DOM
             if (isSettingEnabled(settingsConfig, TextParameters.SignallingServerUrl))
@@ -187,9 +190,9 @@ export class ConfigUI {
                 );
         }
 
-        if (isSectionEnabled(settingsConfig, Sections.UI)) {
+        if (isSectionEnabled(settingsConfig, SettingsSections.UI)) {
             /* Setup all view/ui related settings under this section */
-            const viewSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.UI);
+            const viewSettingsSection = this.buildSectionWithHeading(settingsElem, SettingsSections.UI);
             if (isSettingEnabled(settingsConfig, Flags.MatchViewportResolution))
                 this.addSettingFlag(viewSettingsSection, this.flagsUi.get(Flags.MatchViewportResolution));
 
@@ -200,9 +203,9 @@ export class ConfigUI {
                 this.addSettingFlag(viewSettingsSection, this.flagsUi.get(ExtraFlags.LightMode));
         }
 
-        if (isSectionEnabled(settingsConfig, Sections.Input)) {
+        if (isSectionEnabled(settingsConfig, SettingsSections.Input)) {
             /* Setup all encoder related settings under this section */
-            const inputSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.Input);
+            const inputSettingsSection = this.buildSectionWithHeading(settingsElem, SettingsSections.Input);
 
             if (isSettingEnabled(settingsConfig, Flags.KeyboardInput))
                 this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.KeyboardInput));
@@ -223,9 +226,12 @@ export class ConfigUI {
                 this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.XRControllerInput));
         }
 
-        if (isSectionEnabled(settingsConfig, Sections.Encoder)) {
+        if (isSectionEnabled(settingsConfig, SettingsSections.Encoder)) {
             /* Setup all encoder related settings under this section */
-            const encoderSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.Encoder);
+            const encoderSettingsSection = this.buildSectionWithHeading(
+                settingsElem,
+                SettingsSections.Encoder
+            );
 
             if (isSettingEnabled(settingsConfig, NumericParameters.CompatQualityMin))
                 this.addSettingNumeric(
@@ -260,9 +266,9 @@ export class ConfigUI {
                 );
         }
 
-        if (isSectionEnabled(settingsConfig, Sections.WebRTC)) {
+        if (isSectionEnabled(settingsConfig, SettingsSections.WebRTC)) {
             /* Setup all webrtc related settings under this section */
-            const webrtcSettingsSection = this.buildSectionWithHeading(settingsElem, Sections.WebRTC);
+            const webrtcSettingsSection = this.buildSectionWithHeading(settingsElem, SettingsSections.WebRTC);
 
             if (isSettingEnabled(settingsConfig, NumericParameters.WebRTCFPS))
                 this.addSettingNumeric(

--- a/Frontend/ui-library/src/UI/DataChannelLatencyTest.ts
+++ b/Frontend/ui-library/src/UI/DataChannelLatencyTest.ts
@@ -1,7 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 import { Logger, DataChannelLatencyTestResult } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
-import { Sections } from './UIConfigurationTypes';
+import { StatsSections } from './UIConfigurationTypes';
 
 /**
  * DataChannel Latency test UI elements and results handling.
@@ -27,7 +27,7 @@ export class DataChannelLatencyTest {
             this._rootElement.appendChild(heading);
 
             const headingText = document.createElement('div');
-            headingText.innerHTML = Sections.DataChannelLatencyTest;
+            headingText.innerHTML = StatsSections.DataChannelLatencyTest;
             heading.appendChild(headingText);
             heading.appendChild(this.latencyTestButton);
 

--- a/Frontend/ui-library/src/UI/DataChannelLatencyTest.ts
+++ b/Frontend/ui-library/src/UI/DataChannelLatencyTest.ts
@@ -1,6 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 import { Logger, DataChannelLatencyTestResult } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
+import { Sections } from './UIConfigurationTypes';
 
 /**
  * DataChannel Latency test UI elements and results handling.
@@ -26,7 +27,7 @@ export class DataChannelLatencyTest {
             this._rootElement.appendChild(heading);
 
             const headingText = document.createElement('div');
-            headingText.innerHTML = 'Data Channel Latency Test';
+            headingText.innerHTML = Sections.DataChannelLatencyTest;
             heading.appendChild(headingText);
             heading.appendChild(this.latencyTestButton);
 

--- a/Frontend/ui-library/src/UI/LatencyTest.ts
+++ b/Frontend/ui-library/src/UI/LatencyTest.ts
@@ -2,7 +2,7 @@
 
 import { LatencyTestResults } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
 import { Logger } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
-import { Sections } from './UIConfigurationTypes';
+import { StatsSections } from './UIConfigurationTypes';
 
 /**
  * Latency test UI elements and results handling.
@@ -28,7 +28,7 @@ export class LatencyTest {
             this._rootElement.appendChild(heading);
 
             const headingText = document.createElement('div');
-            headingText.innerHTML = Sections.LatencyTest;
+            headingText.innerHTML = StatsSections.LatencyTest;
             heading.appendChild(headingText);
             heading.appendChild(this.latencyTestButton);
 

--- a/Frontend/ui-library/src/UI/LatencyTest.ts
+++ b/Frontend/ui-library/src/UI/LatencyTest.ts
@@ -2,6 +2,7 @@
 
 import { LatencyTestResults } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
 import { Logger } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
+import { Sections } from './UIConfigurationTypes';
 
 /**
  * Latency test UI elements and results handling.
@@ -27,7 +28,7 @@ export class LatencyTest {
             this._rootElement.appendChild(heading);
 
             const headingText = document.createElement('div');
-            headingText.innerHTML = 'Latency Test';
+            headingText.innerHTML = Sections.LatencyTest;
             heading.appendChild(headingText);
             heading.appendChild(this.latencyTestButton);
 

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -10,6 +10,7 @@ import {
 import { AggregatedStats } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
 import { MathUtils } from '../Util/MathUtils';
 import { DataChannelLatencyTest } from './DataChannelLatencyTest';
+import { isSectionEnabled, Sections, StatsPanelConfiguration } from './UIConfigurationTypes';
 
 /**
  * A stat structure, an id, the stat string, and the element where it is rendered.
@@ -30,6 +31,7 @@ export class StatsPanel {
     _statsContentElement: HTMLElement;
     _statisticsContainer: HTMLElement;
     _statsResult: HTMLElement;
+    _config: StatsPanelConfiguration;
 
     latencyTest: LatencyTest;
     dataChannelLatencyTest: DataChannelLatencyTest;
@@ -37,7 +39,9 @@ export class StatsPanel {
     /* A map stats we are storing/rendering */
     statsMap = new Map<string, Stat>();
 
-    constructor() {
+    constructor(config: StatsPanelConfiguration) {
+        this._config = config;
+
         this.latencyTest = new LatencyTest();
         this.dataChannelLatencyTest = new DataChannelLatencyTest();
     }
@@ -95,11 +99,18 @@ export class StatsPanel {
             streamToolStats.appendChild(controlStats);
             controlStats.appendChild(statistics);
             statistics.appendChild(statisticsHeader);
-            statisticsHeader.appendChild(sessionStats);
+            if (isSectionEnabled(this._config, Sections.SessionStats)) {
+                statisticsHeader.appendChild(sessionStats);
+            }
             statistics.appendChild(this.statisticsContainer);
 
-            controlStats.appendChild(this.latencyTest.rootElement);
-            controlStats.appendChild(this.dataChannelLatencyTest.rootElement);
+            if (isSectionEnabled(this._config, Sections.LatencyTest)) {
+                controlStats.appendChild(this.latencyTest.rootElement);
+            }
+
+            if (isSectionEnabled(this._config, Sections.DataChannelLatencyTest)) {
+                controlStats.appendChild(this.dataChannelLatencyTest.rootElement);
+            }
         }
         return this._statsContentElement;
     }
@@ -328,6 +339,10 @@ export class StatsPanel {
      * @param stat - The contents of the stat.
      */
     public addOrUpdateStat(id: string, statLabel: string, stat: string) {
+        if (!isSectionEnabled(this._config, Sections.SessionStats)) {
+            return;
+        }
+
         const statHTML = `${statLabel}: ${stat}`;
 
         if (!this.statsMap.has(id)) {

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -92,14 +92,13 @@ export class StatsPanel {
             statisticsHeader.classList.add('settings-text');
             statisticsHeader.classList.add('settingsHeader');
 
-            const sessionStats = document.createElement('div');
-            sessionStats.innerHTML = 'Session Stats';
-
             this._statsContentElement.appendChild(streamToolStats);
             streamToolStats.appendChild(controlStats);
             controlStats.appendChild(statistics);
             statistics.appendChild(statisticsHeader);
             if (isSectionEnabled(this._config, Sections.SessionStats)) {
+                const sessionStats = document.createElement('div');
+                sessionStats.innerHTML = Sections.SessionStats;
                 statisticsHeader.appendChild(sessionStats);
             }
             statistics.appendChild(this.statisticsContainer);

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -10,7 +10,7 @@ import {
 import { AggregatedStats } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
 import { MathUtils } from '../Util/MathUtils';
 import { DataChannelLatencyTest } from './DataChannelLatencyTest';
-import { isSectionEnabled, Sections, StatsPanelConfiguration } from './UIConfigurationTypes';
+import { isSectionEnabled, StatsSections, StatsPanelConfiguration } from './UIConfigurationTypes';
 
 /**
  * A stat structure, an id, the stat string, and the element where it is rendered.
@@ -96,18 +96,18 @@ export class StatsPanel {
             streamToolStats.appendChild(controlStats);
             controlStats.appendChild(statistics);
             statistics.appendChild(statisticsHeader);
-            if (isSectionEnabled(this._config, Sections.SessionStats)) {
+            if (isSectionEnabled(this._config, StatsSections.SessionStats)) {
                 const sessionStats = document.createElement('div');
-                sessionStats.innerHTML = Sections.SessionStats;
+                sessionStats.innerHTML = StatsSections.SessionStats;
                 statisticsHeader.appendChild(sessionStats);
             }
             statistics.appendChild(this.statisticsContainer);
 
-            if (isSectionEnabled(this._config, Sections.LatencyTest)) {
+            if (isSectionEnabled(this._config, StatsSections.LatencyTest)) {
                 controlStats.appendChild(this.latencyTest.rootElement);
             }
 
-            if (isSectionEnabled(this._config, Sections.DataChannelLatencyTest)) {
+            if (isSectionEnabled(this._config, StatsSections.DataChannelLatencyTest)) {
                 controlStats.appendChild(this.dataChannelLatencyTest.rootElement);
             }
         }
@@ -338,7 +338,7 @@ export class StatsPanel {
      * @param stat - The contents of the stat.
      */
     public addOrUpdateStat(id: string, statLabel: string, stat: string) {
-        if (!isSectionEnabled(this._config, Sections.SessionStats)) {
+        if (!isSectionEnabled(this._config, StatsSections.SessionStats)) {
             return;
         }
 

--- a/Frontend/ui-library/src/UI/UIConfigurationTypes.ts
+++ b/Frontend/ui-library/src/UI/UIConfigurationTypes.ts
@@ -13,6 +13,25 @@ export type FlagsIdsExtended = FlagsIds | ExtraFlagsIds;
 
 export type OptionIdsExtended = OptionIds | ExtraFlagsIds;
 
+/**
+ * All the UI sections across all the panels.
+ */
+export class Sections {
+    static PixelStreaming = 'Pixel Streaming' as const;
+    static UI = 'UI' as const;
+    static Input = 'Input' as const;
+    static Encoder = 'Encoder' as const;
+    static WebRTC = 'WebRTC' as const;
+    static Commands = 'Commands' as const;
+
+    static SessionStats = 'Session Stats' as const;
+    static LatencyTest = 'Latency Test' as const;
+    static DataChannelLatencyTest = 'Data Channel Latency Test' as const;
+}
+
+export type SectionsKeys = Exclude<keyof typeof Sections, 'prototype'>;
+export type SectionsIds = (typeof Sections)[SectionsKeys];
+
 /** Whether a stream UI element is internally made, externally provided, or disabled. */
 export enum UIElementCreationMode {
     CreateDefaultElement,
@@ -48,23 +67,38 @@ export function isPanelEnabled(config: PanelConfiguration | undefined): boolean 
 }
 
 /**
+ * Type for all settings and a boolean to represent whether this UI section is enabled
+ */
+export type AllSectionsConfig = {
+    [K in SectionsIds]: boolean;
+};
+
+export type SectionsConfiguration = {
+    sectionVisibility?: Partial<AllSectionsConfig>;
+};
+
+export function isSectionEnabled(config: SectionsConfiguration | undefined, section: SectionsIds): boolean {
+    return (
+        !config ||
+        (!!config &&
+            (!Object.prototype.hasOwnProperty.call(config.sectionVisibility, section) ||
+                (Object.prototype.hasOwnProperty.call(config.sectionVisibility, section) && config.sectionVisibility[section])))
+    );
+}
+
+/**
  * Type for all settings and a boolean to represent whether this setting UI is enabled
  */
 export type AllSettingsConfig = {
     [K in OptionIdsExtended]: boolean;
 };
 
-type SettingsConfiguration = {
+export type SettingsConfiguration = {
     settingVisibility?: Partial<AllSettingsConfig>;
 };
 
-/**
- * Overriden panel configuration to include setting visibility for the settings panel
- */
-export type SettingsPanelConfiguration = PanelConfiguration & SettingsConfiguration;
-
 export function isSettingEnabled(
-    config: SettingsPanelConfiguration | undefined,
+    config: SettingsConfiguration | undefined,
     setting: OptionIdsExtended
 ): boolean {
     return (
@@ -75,3 +109,13 @@ export function isSettingEnabled(
                     config.settingVisibility[setting])))
     );
 }
+
+/**
+ * Overriden panel configuration to include section visibility for the stats panel
+ */
+export type StatsPanelConfiguration = PanelConfiguration & SectionsConfiguration;
+
+/**
+ * Overriden panel configuration to include setting and section visibility for the settings panel
+ */
+export type SettingsPanelConfiguration = PanelConfiguration & SettingsConfiguration & SectionsConfiguration;

--- a/Frontend/ui-library/src/UI/UIConfigurationTypes.ts
+++ b/Frontend/ui-library/src/UI/UIConfigurationTypes.ts
@@ -82,7 +82,8 @@ export function isSectionEnabled(config: SectionsConfiguration | undefined, sect
         !config ||
         (!!config &&
             (!Object.prototype.hasOwnProperty.call(config.sectionVisibility, section) ||
-                (Object.prototype.hasOwnProperty.call(config.sectionVisibility, section) && config.sectionVisibility[section])))
+                (Object.prototype.hasOwnProperty.call(config.sectionVisibility, section) &&
+                    config.sectionVisibility[section])))
     );
 }
 

--- a/Frontend/ui-library/src/UI/UIConfigurationTypes.ts
+++ b/Frontend/ui-library/src/UI/UIConfigurationTypes.ts
@@ -16,21 +16,28 @@ export type OptionIdsExtended = OptionIds | ExtraFlagsIds;
 /**
  * All the UI sections across all the panels.
  */
-export class Sections {
+export class SettingsSections {
     static PixelStreaming = 'Pixel Streaming' as const;
     static UI = 'UI' as const;
     static Input = 'Input' as const;
     static Encoder = 'Encoder' as const;
     static WebRTC = 'WebRTC' as const;
     static Commands = 'Commands' as const;
+}
 
+export type SettingsSectionsKeys = Exclude<keyof typeof SettingsSections, 'prototype'>;
+export type SettingsSectionsIds = (typeof SettingsSections)[SettingsSectionsKeys];
+
+export class StatsSections {
     static SessionStats = 'Session Stats' as const;
     static LatencyTest = 'Latency Test' as const;
     static DataChannelLatencyTest = 'Data Channel Latency Test' as const;
 }
 
-export type SectionsKeys = Exclude<keyof typeof Sections, 'prototype'>;
-export type SectionsIds = (typeof Sections)[SectionsKeys];
+export type StatsSectionsKeys = Exclude<keyof typeof StatsSections, 'prototype'>;
+export type StatsSectionsIds = (typeof StatsSections)[StatsSectionsKeys];
+
+export type SectionsIds = SettingsSectionsIds | StatsSectionsIds;
 
 /** Whether a stream UI element is internally made, externally provided, or disabled. */
 export enum UIElementCreationMode {
@@ -67,17 +74,30 @@ export function isPanelEnabled(config: PanelConfiguration | undefined): boolean 
 }
 
 /**
- * Type for all settings and a boolean to represent whether this UI section is enabled
+ * Type for settings sections and a boolean to represent whether this UI section is enabled
  */
-export type AllSectionsConfig = {
-    [K in SectionsIds]: boolean;
+export type SettingsSectionsConfig = {
+    [K in SettingsSectionsIds]: boolean;
 };
 
-export type SectionsConfiguration = {
-    sectionVisibility?: Partial<AllSectionsConfig>;
+export type SettingsSectionsConfiguration = {
+    sectionVisibility?: Partial<SettingsSectionsConfig>;
 };
 
-export function isSectionEnabled(config: SectionsConfiguration | undefined, section: SectionsIds): boolean {
+export type StatsSectionsConfig = {
+    [K in StatsSectionsIds]: boolean;
+};
+
+export type StatsSectionsConfiguration = {
+    sectionVisibility?: Partial<StatsSectionsConfig>;
+};
+
+export type AllSectionsConfiguration = SettingsSectionsConfiguration & StatsSectionsConfiguration;
+
+export function isSectionEnabled(
+    config: AllSectionsConfiguration | undefined,
+    section: SectionsIds
+): boolean {
     return (
         !config ||
         (!!config &&
@@ -114,9 +134,11 @@ export function isSettingEnabled(
 /**
  * Overriden panel configuration to include section visibility for the stats panel
  */
-export type StatsPanelConfiguration = PanelConfiguration & SectionsConfiguration;
+export type StatsPanelConfiguration = PanelConfiguration & StatsSectionsConfiguration;
 
 /**
  * Overriden panel configuration to include setting and section visibility for the settings panel
  */
-export type SettingsPanelConfiguration = PanelConfiguration & SettingsConfiguration & SectionsConfiguration;
+export type SettingsPanelConfiguration = PanelConfiguration &
+    SettingsConfiguration &
+    SettingsSectionsConfiguration;


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Similar to https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/372, but this time on a per section. This stems from the fact that you could disable all the settings in a section individually, but you would still get the section header remaining.

## Solution
Similar fashion to https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/372

## Example Usage
Using the example below results in the attached image.
```ts
const application = new Application({
		stream,
		onColorModeChanged: (isLightMode) => PixelStreamingApplicationStyles.setColorMode(isLightMode),
		settingsPanelConfig: {
			isEnabled: true,
			settingVisibility: {
			  StreamerId: false,
			  ss: false,
			  TimeoutIfIdle: false,
			  ForceTURN: false,
			  LightMode: false,
			  UseMic: false,
			  MatchViewportRes: false,
			  HoveringMouse: false,
			  AFKTimeout: false,
			  AFKCountdown: false,
			  MaxReconnectAttempts: false,
			  StartVideoMuted: false
			},
			sectionVisibility: {
			  Encoder: false,
			  WebRTC: false,
			  UI: false,
			  Input: false
			}
		  }
	});
```

![image](https://github.com/user-attachments/assets/9eaa31d1-5389-41f5-8670-90fc2a272e14)

