### PR TITLE
Adding a pre commit check for npm libraries

### DIFF
--- a/Extras/Scripts/pre-commit-checks.sh
+++ b/Extras/Scripts/pre-commit-checks.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+LINT_CHECK_PATHS=(
+    "Common/"
+    "Signalling/"
+    "Frontend/library/"
+    "Frontend/ui-library/"
+    "SignallingWebServer/"
+)
+
+FAILURE=0
+FAILED_PATHS=()
+
+for CHECK_PATH in "${LINT_CHECK_PATHS[@]}"; do
+    STAGED_FILES=$(git diff --name-only --cached "$CHECK_PATH")
+
+    # check if any of the npm packages have changes
+    if [[ -n "$STAGED_FILES" ]]; then
+        echo ${CHECK_PATH} has changes. Running lint...
+        pushd $CHECK_PATH >/dev/null
+        if ! npm run lint; then
+            FAILURE=1
+            FAILED_PATHS+=("$CHECK_PATH")
+        fi
+        popd >/dev/null
+    fi
+done
+
+if [[ $FAILURE -eq 1 ]]; then
+    echo Linting failures in the following paths...
+    for FAILED_PATH in "${FAILED_PATHS[@]}"; do
+        echo "    $FAILED_PATH"
+    done
+    exit 1
+fi
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,10 @@
 				"Signalling",
 				"SignallingWebServer",
 				"SS_Test"
-			]
+			],
+			"dependencies": {
+				"pre-commit": "^1.2.2"
+			}
 		},
 		"Common": {
 			"name": "@epicgames-ps/lib-pixelstreamingcommon-ue5.5",
@@ -2824,11 +2827,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"Extras/JSStreamer/node_modules/isarray": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"Extras/JSStreamer/node_modules/jju": {
 			"version": "1.4.0",
 			"dev": true,
@@ -3201,11 +3199,6 @@
 				"lodash": "^4.17.20",
 				"renderkid": "^3.0.0"
 			}
-		},
-		"Extras/JSStreamer/node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT"
 		},
 		"Extras/JSStreamer/node_modules/pstree.remy": {
 			"version": "1.1.8",
@@ -3592,11 +3585,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"Extras/JSStreamer/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT"
 		},
 		"Extras/JSStreamer/node_modules/utila": {
 			"version": "0.4.0",
@@ -4670,11 +4658,6 @@
 				"node": ">=8"
 			}
 		},
-		"Frontend/implementations/react/node_modules/isarray": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"Frontend/implementations/react/node_modules/launch-editor": {
 			"version": "2.6.0",
 			"dev": true,
@@ -4975,11 +4958,6 @@
 				"node": ">= 0.6.0"
 			}
 		},
-		"Frontend/implementations/react/node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"Frontend/implementations/react/node_modules/react": {
 			"version": "18.2.0",
 			"license": "MIT",
@@ -5252,11 +5230,6 @@
 			"dependencies": {
 				"inherits": "2.0.3"
 			}
-		},
-		"Frontend/implementations/react/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT"
 		},
 		"Frontend/implementations/react/node_modules/utila": {
 			"version": "0.4.0",
@@ -6353,11 +6326,6 @@
 				"node": ">=8"
 			}
 		},
-		"Frontend/implementations/typescript/node_modules/isarray": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"Frontend/implementations/typescript/node_modules/lower-case": {
 			"version": "2.0.2",
 			"dev": true,
@@ -6639,11 +6607,6 @@
 				"node": ">= 0.6.0"
 			}
 		},
-		"Frontend/implementations/typescript/node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"Frontend/implementations/typescript/node_modules/readable-stream": {
 			"version": "3.6.0",
 			"dev": true,
@@ -6892,11 +6855,6 @@
 			"dependencies": {
 				"inherits": "2.0.3"
 			}
-		},
-		"Frontend/implementations/typescript/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT"
 		},
 		"Frontend/implementations/typescript/node_modules/utila": {
 			"version": "0.4.0",
@@ -11109,7 +11067,6 @@
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bytes": {
@@ -11306,6 +11263,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"engines": [
+				"node >= 0.8"
+			],
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
 		"node_modules/configstore": {
 			"version": "5.0.1",
 			"dev": true,
@@ -11352,7 +11323,6 @@
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/create-jest": {
@@ -13631,6 +13601,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"license": "ISC"
@@ -14454,6 +14429,14 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/os-shim": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+			"integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"dev": true,
@@ -14699,6 +14682,71 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/pre-commit": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+			"integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"cross-spawn": "^5.0.1",
+				"spawn-sync": "^1.0.15",
+				"which": "1.2.x"
+			}
+		},
+		"node_modules/pre-commit/node_modules/cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+			"dependencies": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"node_modules/pre-commit/node_modules/lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/pre-commit/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pre-commit/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pre-commit/node_modules/which": {
+			"version": "1.2.14",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/pre-commit/node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"dev": true,
@@ -14760,6 +14808,11 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"dev": true,
@@ -14786,6 +14839,11 @@
 		"node_modules/prtest": {
 			"resolved": "Extras/MinimalStreamTester",
 			"link": true
+		},
+		"node_modules/pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
 		},
 		"node_modules/psl": {
 			"version": "1.13.0",
@@ -14906,6 +14964,25 @@
 			"license": "MIT",
 			"optional": true,
 			"peer": true
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/rechoir": {
 			"version": "0.8.0",
@@ -15264,6 +15341,16 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/spawn-sync": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+			"integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"concat-stream": "^1.4.7",
+				"os-shim": "^0.1.2"
+			}
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"license": "BSD-3-Clause"
@@ -15297,6 +15384,19 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -15653,6 +15753,11 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+		},
 		"node_modules/typedarray-to-buffer": {
 			"version": "3.1.5",
 			"dev": true,
@@ -15752,6 +15857,11 @@
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",
@@ -17363,10 +17473,6 @@
 				"node": ">=14.0"
 			}
 		},
-		"Signalling/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"license": "MIT"
-		},
 		"Signalling/node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
 			"dev": true,
@@ -18551,10 +18657,6 @@
 			"engines": {
 				"node": ">=14.0"
 			}
-		},
-		"SignallingWebServer/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"license": "MIT"
 		},
 		"SignallingWebServer/node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
 	],
 	"private": true,
 	"scripts": {
-		"build": "npm run build --ws"
+		"build": "npm run build --ws",
+        "pre-commit-lint": "Extras/Scripts/pre-commit-checks.sh"
+	},
+    "pre-commit": [
+        "pre-commit-lint"
+    ],
+	"dependencies": {
+		"pre-commit": "^1.2.2"
 	}
-  }
+}

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-	"name": "pixelstreaming-infrastructure",
-	"workspaces": [
-		"Common",
-		"Extras/FrontendTests",
-		"Extras/JSStreamer",
-		"Extras/MinimalStreamTester",
-		"Frontend/library",
-		"Frontend/ui-library",
-		"Frontend/implementations/typescript",
-		"Frontend/implementations/react",
-		"SFU",
-		"SFU/mediasoup-sdp-bridge",
-		"Signalling",
-		"SignallingWebServer",
-		"SS_Test"
-	],
-	"private": true,
-	"scripts": {
-		"build": "npm run build --ws",
+    "name": "pixelstreaming-infrastructure",
+    "workspaces": [
+        "Common",
+        "Extras/FrontendTests",
+        "Extras/JSStreamer",
+        "Extras/MinimalStreamTester",
+        "Frontend/library",
+        "Frontend/ui-library",
+        "Frontend/implementations/typescript",
+        "Frontend/implementations/react",
+        "SFU",
+        "SFU/mediasoup-sdp-bridge",
+        "Signalling",
+        "SignallingWebServer",
+        "SS_Test"
+    ],
+    "private": true,
+    "scripts": {
+        "build": "npm run build --ws",
         "pre-commit-lint": "Extras/Scripts/pre-commit-checks.sh"
-	},
+    },
     "pre-commit": [
         "pre-commit-lint"
     ],
-	"dependencies": {
-		"pre-commit": "^1.2.2"
-	}
+    "dependencies": {
+        "pre-commit": "^1.2.2"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build --ws",
-        "pre-commit-lint": "Extras/Scripts/pre-commit-checks.sh"
+        "pre-commit-lint": "bash ./Extras/Scripts/pre-commit-checks.sh"
     },
     "pre-commit": [
         "pre-commit-lint"


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU
- [x] Other

## Problem statement:
It's common to commit your work and build a PR only to later realise you forgot to run lint checks and the github actions fail, sometimes after a long while. This can lead to wasted time and frustrations.

## Solution
This installs a git pre-commit hook that will cycle through the npm libraries and if there are staged files in them it will run lint allowing you to get earlier notification of any linting issues before you actually commit. This should help reduce the number of "Fixing linting issues" commits.

This uses an npm package `pre-commit` in the root package.json which should automatically install the pre-commit hooks when you first do an `npm i`.

