### PR TITLE
Fixing develop/watch scripts for windows

### DIFF
--- a/Common/package.json
+++ b/Common/package.json
@@ -16,10 +16,11 @@
         "build:esm": "tsc --project tsconfig.esm.json",
         "build": "npm run build:proto && npm run build:cjs && npm run build:esm",
         "rebuild": "npm run clean && npm run build",
-        "watch:proto": "nodemon -V -d 3 --watch protobuf/signalling_messages.proto --exec 'npm run build:proto'",
+        "watch:proto": "nodemon -V -d 3 --watch protobuf/signalling_messages.proto --exec \"npm run build:proto\"",
         "watch": "concurrently -k \"npm run watch:proto\" \"tsc --watch --preserveWatchOutput --project tsconfig.cjs.json\"",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "wtf": "concurrently -k \"npm list\""
     },
     "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/Frontend/library/package.json
+++ b/Frontend/library/package.json
@@ -12,7 +12,7 @@
         "build:esm": "tsc --project tsconfig.esm.json",
         "build": "npm run build:cjs && npm run build:esm",
         "rebuild": "npm run clean && npm run build",
-        "watch": "nodemon -V -d 3 --watch src --watch ../../Common/dist -e 'ts,js,mjs,cjs,json' --exec 'npm run build:cjs'",
+        "watch": "nodemon -V -d 3 --watch src --watch ../../Common/dist -e \"ts,js,mjs,cjs,json\" --exec \"npm run build:cjs\"",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
         "test": "jest --detectOpenHandles --coverage=true",
         "spellcheck": "cspell \"{README.md,.github/*.md,src/**/*.ts}\""

--- a/Frontend/ui-library/package.json
+++ b/Frontend/ui-library/package.json
@@ -12,7 +12,7 @@
         "build:esm": "tsc --project tsconfig.esm.json",
         "build": "npm run build:cjs && npm run build:esm",
         "rebuild": "npm run clean && npm run build",
-        "watch": "nodemon -V -d 3 --watch src --watch ../library/dist -e 'ts,js,mjs,cjs,json' --exec 'npm run build:cjs'",
+        "watch": "nodemon -V -d 3 --watch src --watch ../library/dist -e \"ts,js,mjs,cjs,json\" --exec \"npm run build:cjs\"",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
         "spellcheck": "cspell \"{README.md,.github/*.md,src/**/*.ts}\""
     },

--- a/Signalling/package.json
+++ b/Signalling/package.json
@@ -12,7 +12,7 @@
         "build:esm": "tsc --project tsconfig.esm.json",
         "build": "npm run build:cjs && npm run build:esm",
         "rebuild": "npm run clean && npm run build",
-        "watch": "nodemon -V -d 3 --watch src --watch ../Common/dist -e 'ts,js,mjs,cjs,json' --exec 'npm run build:cjs'",
+        "watch": "nodemon -V -d 3 --watch src --watch ../Common/dist -e \"ts,js,mjs,cjs,json\" --exec \"npm run build:cjs\"",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/SignallingWebServer/package.json
+++ b/SignallingWebServer/package.json
@@ -10,8 +10,8 @@
         "start": "node ./dist/index.js --serve --console_messages verbose --log_config --https_redirect",
         "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "watch": "nodemon -V -d 3 --watch src --watch ../Signalling/dist -e 'ts,js,mjs,cjs,json' --exec 'npm run build && node ./dist/index.js --serve --console_messages verbose --log_config --https_redirect --player_port 1025' --http_root www",
-        "develop": "cd ../ && npm run build:all:cjs && cd - && concurrently -k \"cd ../Common && npm run watch\" \"cd ../Signalling && npm run watch\" \"cd ../Frontend/library && npm run watch\" \"cd ../Frontend/ui-library && npm run watch\" \"cd ../Frontend/implementations/typescript && npm run watch\"  \"npm run watch\""
+        "watch": "nodemon -V -d 3 --watch src --watch ../Signalling/dist -e \"ts,js,mjs,cjs,json\" --exec \"npm run build && node ./dist/index.js --serve --console_messages verbose --log_config --https_redirect --player_port 1025\" --http_root www",
+        "develop": "cd ../ && npm run build:all:cjs && cd SignallingWebServer && concurrently -k \"cd ../Common && npm run watch\" \"cd ../Signalling && npm run watch\" \"cd ../Frontend/library && npm run watch\" \"cd ../Frontend/ui-library && npm run watch\" \"cd ../Frontend/implementations/typescript && npm run watch\"  \"npm run watch\""
     },
     "author": "Epic Games",
     "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15549,8 +15549,8 @@
                 "openapi-typescript": "^7.0.0",
                 "prettier": "3.3.3",
                 "ts-node": "^10.9.2",
-                "typedoc": "^0.25.8",
-                "typedoc-plugin-markdown": "^3.17.1",
+                "typedoc": "^0.27.4",
+                "typedoc-plugin-markdown": "^4.3.2",
                 "typescript": "^5.0.0"
             }
         },
@@ -15868,6 +15868,20 @@
             },
             "engines": {
                 "node": ">= 12.0.0"
+            }
+        },
+        "Signalling/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "Signalling/node_modules/mkdirp": {
@@ -16241,34 +16255,37 @@
             }
         },
         "Signalling/node_modules/typedoc": {
-            "version": "0.25.8",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.7.tgz",
+            "integrity": "sha512-K/JaUPX18+61W3VXek1cWC5gwmuLvYTOXJzBvD9W7jFvbPnefRnCHQCEPw7MSNrP/Hj7JJrhZtDDLKdcYm6ucg==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
+                "@gerrit0/mini-shiki": "^1.24.0",
                 "lunr": "^2.3.9",
-                "marked": "^4.3.0",
-                "minimatch": "^9.0.3",
-                "shiki": "^0.14.7"
+                "markdown-it": "^14.1.0",
+                "minimatch": "^9.0.5",
+                "yaml": "^2.6.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
             },
             "engines": {
-                "node": ">= 16"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
             }
         },
         "Signalling/node_modules/typedoc-plugin-markdown": {
-            "version": "3.17.1",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.4.2.tgz",
+            "integrity": "sha512-kJVkU2Wd+AXQpyL6DlYXXRrfNrHrEIUgiABWH8Z+2Lz5Sq6an4dQ/hfvP75bbokjNDUskOdFlEEm/0fSVyC7eg==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "handlebars": "^4.7.7"
+            "engines": {
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "typedoc": ">=0.24.0"
+                "typedoc": "0.27.x"
             }
         },
         "Signalling/node_modules/typescript": {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
Develop script was broken on windows

## Solution
Seems that the quotation type mattered on windows but not linux. I have changed and tested each of the watch and develop scripts on windows now and it appears to be fine.
