### PR TITLE
Fix: Git bash failing to run platform scripts on Windows due to tar conflict

### DIFF
--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -122,7 +122,7 @@ if exist node\ (
   rem Download nodejs and follow redirects.
   curl -L -o ./node.zip "https://nodejs.org/dist/%NODE_VERSION%/%NODE_NAME%.zip"
 
-  tar -xf node.zip
+  %SystemRoot%\System32\tar.exe -xf node.zip
   ren "%NODE_NAME%\" "node"
   del node.zip
 )
@@ -206,7 +206,7 @@ if exist coturn\ (
   curl -L -o ./turnserver.zip "https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases/download/v4.5.2-coturn-windows/turnserver.zip"
 
   @Rem Unarchive the .zip to a directory called "turnserver"
-  mkdir coturn & tar -xf turnserver.zip -C coturn
+  mkdir coturn & %SystemRoot%\System32\tar.exe -xf turnserver.zip -C coturn
 
   @Rem Delete the downloaded turnserver.zip
   del turnserver.zip

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -8,6 +8,7 @@ goto :eof
 set SCRIPT_DIR=%~dp0
 set NODE_VERSION=v18.17.0
 set NPM="%SCRIPT_DIR%/node/npm"
+set TAR="%SystemRoot%\System32\tar.exe"
 set CONTINUE=1
 GOTO :eof
 
@@ -122,7 +123,7 @@ if exist node\ (
   rem Download nodejs and follow redirects.
   curl -L -o ./node.zip "https://nodejs.org/dist/%NODE_VERSION%/%NODE_NAME%.zip"
 
-  %SystemRoot%\System32\tar.exe -xf node.zip
+  %TAR% -xf node.zip
   ren "%NODE_NAME%\" "node"
   del node.zip
 )
@@ -206,7 +207,7 @@ if exist coturn\ (
   curl -L -o ./turnserver.zip "https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases/download/v4.5.2-coturn-windows/turnserver.zip"
 
   @Rem Unarchive the .zip to a directory called "turnserver"
-  mkdir coturn & %SystemRoot%\System32\tar.exe -xf turnserver.zip -C coturn
+  mkdir coturn & %TAR% -xf turnserver.zip -C coturn
 
   @Rem Delete the downloaded turnserver.zip
   del turnserver.zip


### PR DESCRIPTION
## Relevant components:
- [x] Platform scripts

## Problem statement:
Some users want to use Git bash on Windows to run the `platform_scripts/cmd`.
This currently fails as Git bash ships its own (gnu) `tar` which does not support `.zip` files.
Our intent is to use (bsd)`tar` that ships with Windows.

Closes https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues/473

## Solution
The solution is to explicitly call (bsd) tar which resides in `System32`

## Documentation
N/A

## Test Plan and Compatibility
Tested with Git bash and cmd.exe both now work.
