### PR TITLE
Update helmet Content Security Policy to allow websocket connections to sources other than the location where the frontend is hosted

### DIFF
--- a/Signalling/src/WebServer.ts
+++ b/Signalling/src/WebServer.ts
@@ -69,13 +69,15 @@ export class WebServer {
                 Logger.info(`Https server listening on port ${config.httpsPort}`);
             });
 
-            app.use(helmet({
-                contentSecurityPolicy: {
-                    directives: {
-                        "connect-src": ["*", "'self'"]
+            app.use(
+                helmet({
+                    contentSecurityPolicy: {
+                        directives: {
+                            'connect-src': ['*', "'self'"]
+                        }
                     }
-                }
-            }));
+                })
+            );
 
             app.use(
                 hsts({

--- a/Signalling/src/WebServer.ts
+++ b/Signalling/src/WebServer.ts
@@ -7,7 +7,7 @@ import helmet from 'helmet';
 import { Logger } from './Logger';
 import RateLimit from 'express-rate-limit';
 
-// eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const hsts = require('hsts');
 
 /**
@@ -69,7 +69,14 @@ export class WebServer {
                 Logger.info(`Https server listening on port ${config.httpsPort}`);
             });
 
-            app.use(helmet());
+            app.use(helmet({
+                contentSecurityPolicy: {
+                    directives: {
+                        "connect-src": ["*", "'self'"]
+                    }
+                }
+            }));
+
             app.use(
                 hsts({
                     maxAge: 15552000 // 180 days in seconds


### PR DESCRIPTION
# Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Signalling library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Due to web content security policies, websocket connections to locations other than the same location that the page is hosted from are disallowed. This means that if you were to use a frontend hosted in location X, and a signalling server in location Y, and connect to the frontend with `http://LocationX?ss=LocationY`, you won't be able to establish a connection.

## Solution
Update the default content security policy used by helmet to allow websocket connections from different locations