### PR TITLE
Make abs-capture-time flag false by default

### DIFF
--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -573,7 +573,7 @@ export class Config {
                 'Enables the abs-capture-time RTP header extension',
                 settings && Object.prototype.hasOwnProperty.call(settings, Flags.EnableCaptureTimeExt)
                     ? settings[Flags.EnableCaptureTimeExt]
-                    : true,
+                    : false,
                 useUrlParams
             )
         );


### PR DESCRIPTION
## Relevant components:
- [x] Frontend library

## Problem statement:
`abs-capture-time` flag is an opt-in flag, the default should be false, so users can opt-in should they so wish. Due to the flag currently being true this is causing issues with older Chromium clients that do not yet support abs-capture-time https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/425#discussion_r1976665497

This will not impact latency calculations feature added in https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/425 as these use the video-timing RTP header extension presently (which we do not have to enable).

## Solution
Flag is made `false` by default.

## Documentation
N/A

## Test Plan and Compatibility
Unit tests exist for this flag. If they pass that should be sufficient.
