### PR TITLE
Fix edit text button not showing and warnings on desktop

### DIFF
--- a/Frontend/library/src/UI/OnScreenKeyboard.ts
+++ b/Frontend/library/src/UI/OnScreenKeyboard.ts
@@ -81,9 +81,13 @@ export class OnScreenKeyboard {
      * @param command the command received via the data channel containing keyboard positions
      */
     showOnScreenKeyboard(command: any) {
+        if (!this.editTextButton) {
+            return;
+        }
+        
         if (command.showOnScreenKeyboard) {
             // Show the 'edit text' button.
-            this.editTextButton.style.display = 'default';
+            this.editTextButton.style.display = 'block';
             // Place the 'edit text' button near the UE input widget.
             const pos = this.unquantizeAndDenormalizeUnsigned(command.x, command.y);
             this.editTextButton.style.top = pos.y.toString() + 'px';


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
`Edit Text` button wasn't showing on mobile. Additionally, updates to UE mean that the `showOnScreenKeyboard` event can be sent when on desktop leading to errors about a null `editTextButton` as that is only created on mobile.

## Solution
Set correct display type for `Edit Text` button and add an additional check to check the validity of `Edit Text` button before trying to do anything with it.

## Test Plan and Compatibility
Tested on iOS and Win11 with Editor Streaming to verify functionality and no warnings.
