### PR TITLE
Websocket subprotocol support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,5 @@
 SignallingWebServer/platform_scripts/cmd/coturn/
 SignallingWebServer/platform_scripts/cmd/node/
 SignallingWebServer/platform_scripts/bash/node/
-SignallingWebServer/platform_scripts/logs/
-SignallingWebServer/platform_scripts/www/
+SignallingWebServer/logs/
+SignallingWebServer/www/

--- a/Common/src/Transport/WebSocketTransport.ts
+++ b/Common/src/Transport/WebSocketTransport.ts
@@ -17,9 +17,15 @@ declare global {
 export class WebSocketTransport extends EventEmitter implements ITransport {
     WS_OPEN_STATE = 1;
     webSocket?: WebSocket;
+    protocols?: string | string[];
 
-    constructor() {
+    /**
+     * Constructs a new WebSocketTransport for browser contexts.
+     * @param protocols - An optional string or list of strings to pass to the new websocket protocols param
+     */
+    constructor(protocols?: string | string[]) {
         super();
+        this.protocols = protocols;
     }
 
     /**
@@ -43,7 +49,7 @@ export class WebSocketTransport extends EventEmitter implements ITransport {
     connect(connectionURL: string): boolean {
         Logger.Info(connectionURL);
         try {
-            this.webSocket = new WebSocket(connectionURL);
+            this.webSocket = new WebSocket(connectionURL, this.protocols);
             this.webSocket.onopen = (_: Event) => this.handleOnOpen();
             this.webSocket.onerror = (_: Event) => this.handleOnError();
             this.webSocket.onclose = (event: CloseEvent) => this.handleOnClose(event);

--- a/Common/src/Transport/WebSocketTransportNJS.ts
+++ b/Common/src/Transport/WebSocketTransportNJS.ts
@@ -13,13 +13,33 @@ import WebSocket from 'ws';
 export class WebSocketTransportNJS extends EventEmitter implements ITransport {
     WS_OPEN_STATE = 1;
     webSocket?: WebSocket;
+    protocols?: string | string[];
 
-    constructor(existingSocket?: WebSocket) {
+    /**
+     * Constructs a new instance of a WebSocketTransport for node contexts.
+     * @param existingSocket - An existing WebSocket to use.
+     */
+    constructor(existingSocket: WebSocket);
+
+    /**
+     * Constructs a new instance of a WebSocketTransport for node contexts.
+     * @param protocols - A protocol or list of protocols to pass to the new websocket.
+     */
+    constructor(protocols: string | string[]);
+
+    /**
+     * Constructs a new instance of a WebSocketTransport for node contexts.
+     */
+    constructor();
+
+    constructor(argument?: WebSocket | string | string[]) {
         super();
-        if (existingSocket) {
-            this.webSocket = existingSocket;
+        if (argument instanceof WebSocket) {
+            this.webSocket = argument;
             this.setupSocketHandlers();
             this.emit('open');
+        } else if (argument) {
+            this.protocols = argument;
         }
     }
 
@@ -39,10 +59,11 @@ export class WebSocketTransportNJS extends EventEmitter implements ITransport {
     /**
      * Connect to the signaling server
      * @param connectionURL - The Address of the signaling server
+     * @param protocols - An optional string or list of strings to pass to the new websocket protocols param
      * @returns If there is a connection
      */
     connect(connectionURL: string): boolean {
-        this.webSocket = new WebSocket(connectionURL);
+        this.webSocket = new WebSocket(connectionURL, this.protocols);
         this.setupSocketHandlers();
         return true;
     }

--- a/Frontend/implementations/typescript/src/player.ts
+++ b/Frontend/implementations/typescript/src/player.ts
@@ -17,7 +17,7 @@ document.body.onload = function() {
     Logger.InitLogging(LogLevel.Warning, true);
 
 	// Create a config object
-	const config = new Config({ useUrlParams: true, webSocketProtocols: ["soap","xamp"] });
+	const config = new Config({ useUrlParams: true });
 
 	// Create the main Pixel Streaming object for interfacing with the web-API of Pixel Streaming
 	const stream = new PixelStreaming(config);

--- a/Frontend/implementations/typescript/src/player.ts
+++ b/Frontend/implementations/typescript/src/player.ts
@@ -17,7 +17,7 @@ document.body.onload = function() {
     Logger.InitLogging(LogLevel.Warning, true);
 
 	// Create a config object
-	const config = new Config({ useUrlParams: true });
+	const config = new Config({ useUrlParams: true, webSocketProtocols: ["soap","xamp"] });
 
 	// Create the main Pixel Streaming object for interfacing with the web-API of Pixel Streaming
 	const stream = new PixelStreaming(config);

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -128,6 +128,8 @@ export interface ConfigParams {
     initialSettings?: Partial<AllSettings>;
     /** If useUrlParams is set true, will read initial values from URL parameters and persist changed settings into URL */
     useUrlParams?: boolean;
+    /** If webSocketProtocols is set the protocols will be passed to the websocket constructor */
+    webSocketProtocols?: string | string[];
 }
 export class Config {
     /* A map of flags that can be toggled - options that can be set in the application - e.g. Use Mic? */
@@ -144,11 +146,14 @@ export class Config {
 
     private _useUrlParams: boolean;
 
+    private _webSocketProtocols?: string | string[];
+
     // ------------ Settings -----------------
 
     constructor(config: ConfigParams = {}) {
-        const { initialSettings, useUrlParams } = config;
+        const { initialSettings, useUrlParams, webSocketProtocols } = config;
         this._useUrlParams = !!useUrlParams;
+        this._webSocketProtocols = webSocketProtocols;
         this.populateDefaultSettings(this._useUrlParams, initialSettings);
     }
 
@@ -161,9 +166,16 @@ export class Config {
     }
 
     /**
+     * Gets a protocol or list of protocols to pass to the websocket if set.
+     */
+    public get webSocketProtocols() {
+        return this._webSocketProtocols;
+    }
+
+    /**
      * Populate the default settings for a Pixel Streaming application
      */
-    private populateDefaultSettings(useUrlParams: boolean, settings: Partial<AllSettings>): void {
+    private populateDefaultSettings(useUrlParams: boolean, settings?: Partial<AllSettings>): void {
         /**
          * Text Parameters
          */

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -169,7 +169,7 @@ export class WebRtcPlayerController {
         this.streamMessageController = new StreamMessageController();
 
         // set up websocket methods
-        this.transport = new WebSocketTransport();
+        this.transport = new WebSocketTransport(config.webSocketProtocols);
         this.protocol = new SignallingProtocol(this.transport);
         this.protocol.addListener(Messages.config.typeName, (msg: BaseMessage) =>
             this.handleOnConfigMessage(msg as Messages.config)

--- a/SignallingWebServer/platform_scripts/bash/setup.sh
+++ b/SignallingWebServer/platform_scripts/bash/setup.sh
@@ -7,4 +7,4 @@ SCRIPT_DIR="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 parse_args $@
 setup $@
-
+build_wilbur


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
#404
We would like to be able to provide websocket protocols to the websocket creation.

## Solution
Added a configuration parameter that allows the user to specify the protocols to the websocket creation.

## Documentation
Updated the typedocs
