### PR TITLE
Exclude dist dir from GH release

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -81,13 +81,14 @@ jobs:
           .github
           output
           node_modules
-          Common/build
+          Common/dist
           Common/docs
           Common/node_modules
           Docs
           Extras
           Frontend/Docs
           Frontend/implementations/typescript/node_modules
+          Frontend/implementations/typescript/dist
           Frontend/library/dist
           Frontend/library/node_modules
           Frontend/library/types
@@ -96,10 +97,10 @@ jobs:
           Frontend/ui-library/types
           SFU/Docs
           SFU/node_modules
-          Signalling/build
+          Signalling/dist
           Signalling/docs
           Signalling/node_modules
-          SignallingWebServer/build
+          SignallingWebServer/dist
           SignallingWebServer/node_modules
           Extras/SS_Test
 
@@ -116,7 +117,7 @@ jobs:
           */node_modules/*
           /*/node_modules/*
           */output/*
-          /*/Common/build/*
+          /*/Common/dist/*
           /*/Common/docs/*
           /*/Common/node_modules/*
           /*/Docs/*
@@ -129,11 +130,12 @@ jobs:
           /*/Frontend/ui-library/types/*
           /*/Frontend/ui-library/node_modules/*
           /*/Frontend/implementations/typescript/node_modules
+          /*/Frontend/implementations/typescript/dist
           /*/SFU/Docs/*
-          /*/Signalling/build/*
+          /*/Signalling/dist/*
           /*/Signalling/docs/*
           /*/Signalling/node_modules/*
-          /*/SignallingWebServer/build/*
+          /*/SignallingWebServer/dist/*
           /*/SignallingWebServer/node_modules/*
 
     - name: "Make the release"


### PR DESCRIPTION
## Relevant components:
- [x] This repo

## Problem statement:
GH release contains `dist` dir for multiple packages in this repo. The release should contain only source, the built frontend, and no build artifacts.

## Solution
Changes the `build` exclusions to `dist` as per the latest changes we have made to building packages in this project.

## Documentation
N/A

## Test Plan and Compatibility
Untested.
