### PR TITLE
Adding the actual server usage to the convenience script when printing usage.

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -30,8 +30,10 @@ function print_usage() {
     Command line options might be omitted to run with defaults and it is a good practice to omit specific ones when just starting the TURN or the STUN server alone, not the whole set of scripts.
     "
     if [[ -d "${SCRIPT_DIR}/../../dist/" ]]; then
+        pushd "${SCRIPT_DIR}/../.."
         echo "Server options:"
         "${NPM}" run start -- --help
+        popd
     fi
     exit 1
 }

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -6,7 +6,7 @@ NPM="${SCRIPT_DIR}/node/bin/npm"
 # Prints the arguments and their descriptions to the console
 function print_usage() {
     echo "
-    Usage:
+    Script usage:
         ${0} [--help] [--publicip <IP Address>] [--turn <turn server>] [--stun <stun server>] [server options...]
     Where:
         --help              Print this message and stop this script.
@@ -29,6 +29,10 @@ function print_usage() {
     Other options: stored and passed to the server.  All parameters printed once the script values are set.
     Command line options might be omitted to run with defaults and it is a good practice to omit specific ones when just starting the TURN or the STUN server alone, not the whole set of scripts.
     "
+    if [[ -d "${SCRIPT_DIR}/../../dist/" ]]; then
+        echo "Server options:"
+        "${NPM}" run start -- --help
+    fi
     exit 1
 }
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When printing help using the start.sh script, the server options remain hidden, obfuscating the settings of the actual server.

## Solution
The usage now calls into the server itself to print its own usage. This is skipped if the server is not built.
