### PR TITLE
Reset preferred codec options on stream disconnect

### DIFF
--- a/Frontend/library/src/Util/BrowserUtils.ts
+++ b/Frontend/library/src/Util/BrowserUtils.ts
@@ -1,0 +1,38 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+import { Logger } from "@epicgames-ps/lib-pixelstreamingcommon-ue5.5";
+
+export class BrowserUtils
+{
+    static getSupportedVideoCodecs(): Array<string> {
+        const browserSupportedCodecs: Array<string> = [];
+        // Try get the info needed from the RTCRtpReceiver. This is only available on chrome
+        if (!RTCRtpReceiver.getCapabilities) {
+            Logger.Warning(
+                'RTCRtpReceiver.getCapabilities API is not available in your browser, defaulting to guess that we support H.264.'
+            );
+            browserSupportedCodecs.push(
+                'H264 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f'
+            );
+            return browserSupportedCodecs;
+        }
+        
+        const matcher = /(VP\d|H26\d|AV1).*/;
+        const capabilities = RTCRtpReceiver.getCapabilities('video');
+        if(!capabilities)
+        {
+            browserSupportedCodecs.push(
+                'H264 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f'
+            );
+            return browserSupportedCodecs;
+        }
+        capabilities.codecs.forEach((codec) => {
+            const str = codec.mimeType.split('/')[1] + ' ' + (codec.sdpFmtpLine || '');
+            const match = matcher.exec(str);
+            if (match !== null) {
+                browserSupportedCodecs.push(str);
+            }
+        });
+        return browserSupportedCodecs;
+    }
+}

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -56,6 +56,7 @@ import { IURLSearchParams } from '../Util/IURLSearchParams';
 import { IInputController } from '../Inputs/IInputController';
 import { GamepadController } from '../Inputs/GamepadController';
 import { LatencyInfo } from '../PeerConnectionController/LatencyCalculator';
+import { BrowserUtils } from '../Util/BrowserUtils';
 
 /**
  * Entry point for the WebRTC Player
@@ -232,6 +233,10 @@ export class WebRtcPlayerController {
 
             this.forceReconnect = false;
 
+            // Reset the list of all possible codecs on disconnect so that if the next connection has "NegotiateCodecs" on
+            // then all codecs can be negotiated
+            this.config.getSettingOption(OptionParameters.PreferredCodec).options = BrowserUtils.getSupportedVideoCodecs();
+            
             this.pixelStreaming._onDisconnect(disconnectMessage, allowClickToReconnect);
 
             this.afkController.stopAfkWarningTimer();


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When using the frontend, if the first stream you connect to isn't launched with `-PixelStreamingNegotiateCodecs`, then the frontend will have the preferred codec option updated to contain only a single codec. If the application was to disconnect and then be relaunched with `-PixelStreamingNegotiateCodecs`, the frontend will still only contain the single codec in the dropdown and therefore wonn't actually negotiate from all supported codecs.

## Solution
Reset the preferred codec options on stream disconnect.