### PR TITLE
Player destroy functionality.

### DIFF
--- a/Frontend/implementations/typescript/src/stresstest.ts
+++ b/Frontend/implementations/typescript/src/stresstest.ts
@@ -1,179 +1,184 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
-import { Config, Flags, PixelStreaming } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
-import { Application, PixelStreamingApplicationStyle } from '@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5';
-const PixelStreamingApplicationStyles =
-    new PixelStreamingApplicationStyle();
+import { Config, Flags, PixelStreaming, Logger, LogLevel } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.5';
+import {
+    Application,
+    PixelStreamingApplicationStyle
+} from '@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5';
+const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
 PixelStreamingApplicationStyles.applyStyleSheet();
 
 export class PixelStreamingFrame {
-	element: HTMLElement;
-	pixelStreamingApp: Application;
+    element: HTMLElement;
+    pixelStreamingApp: Application;
 
-	constructor(element: HTMLElement, pixelStreamingApp: Application) {
-		this.element = element;
-		this.pixelStreamingApp = pixelStreamingApp;
-	}
+    constructor(element: HTMLElement, pixelStreamingApp: Application) {
+        this.element = element;
+        this.pixelStreamingApp = pixelStreamingApp;
+    }
 }
 
 // This is the entrypoint to the stress test, all setup happens here
 export class StressTester {
-	play: boolean;
-	maxPeers: number;
-	totalStreams: number;
-	streamCreationIntervalMs: number;
-	streamDeletionIntervalMs: number;
-	pixelStreamingFrames: Array<PixelStreamingFrame>;
-	creationIntervalHandle: number;
-	deletionIntervalHandle: number;
-	streamsContainer: HTMLElement;
+    play: boolean;
+    maxPeers: number;
+    totalStreams: number;
+    streamCreationIntervalMs: number;
+    streamDeletionIntervalMs: number;
+    pixelStreamingFrames: Array<PixelStreamingFrame>;
+    creationIntervalHandle: number;
+    deletionIntervalHandle: number;
+    streamsContainer: HTMLElement;
 
-	constructor() {
-		this.play = false;
-		this.maxPeers = 3;
-		this.totalStreams = 0;
-		this.streamCreationIntervalMs = 1000;
-		this.streamDeletionIntervalMs = 4000;
-		this.pixelStreamingFrames = [];
-		this.creationIntervalHandle = null;
-		this.deletionIntervalHandle = null;
-		// Get a container to put the "Pixel Streaming" pages in.
-		this.streamsContainer = document.getElementById("streamsContainer");
-	}
+    constructor() {
+        this.play = false;
+        this.maxPeers = 3;
+        this.totalStreams = 0;
+        this.streamCreationIntervalMs = 1000;
+        this.streamDeletionIntervalMs = 4000;
+        this.pixelStreamingFrames = [];
+        this.creationIntervalHandle = null;
+        this.deletionIntervalHandle = null;
+        // Get a container to put the "Pixel Streaming" pages in.
+        this.streamsContainer = document.getElementById('streamsContainer');
+        Logger.InitLogging(LogLevel.Warning, true);
+    }
 
-	startStressTest() : void {
-		this.setupNumPeersSlider();
-		this.startStreamCreation();
-		this.startStreamDeletion();
-		this.setupPlayPause();
+    startStressTest(): void {
+        this.setupNumPeersSlider();
+        this.startStreamCreation();
+        this.startStreamDeletion();
+        this.setupPlayPause();
 
-		document.getElementById("creationIntervalInput").onchange = (event : Event) => {
-			const inputElem = document.getElementById("creationIntervalInput") as HTMLInputElement;
-			const parsedValue = Number.parseInt(inputElem.value);
-			if(!Number.isNaN(parsedValue)) {
-				this.streamCreationIntervalMs = parsedValue * 1000.0;
-				this.startStreamCreation();
-			}
-		}
+        document.getElementById('creationIntervalInput').onchange = (event: Event) => {
+            const inputElem = document.getElementById('creationIntervalInput') as HTMLInputElement;
+            const parsedValue = Number.parseInt(inputElem.value);
+            if (!Number.isNaN(parsedValue)) {
+                this.streamCreationIntervalMs = parsedValue * 1000.0;
+                this.startStreamCreation();
+            }
+        };
 
-		document.getElementById("deletionIntervalInput").onchange = (event: Event) => {
-			const inputElem = document.getElementById("deletionIntervalInput") as HTMLInputElement;
-			const parsedValue = Number.parseInt(inputElem.value);
-			if (!Number.isNaN(parsedValue)) {
-				this.streamDeletionIntervalMs = parsedValue * 1000.0;
-				this.startStreamDeletion();
-			}
-		}
+        document.getElementById('deletionIntervalInput').onchange = (event: Event) => {
+            const inputElem = document.getElementById('deletionIntervalInput') as HTMLInputElement;
+            const parsedValue = Number.parseInt(inputElem.value);
+            if (!Number.isNaN(parsedValue)) {
+                this.streamDeletionIntervalMs = parsedValue * 1000.0;
+                this.startStreamDeletion();
+            }
+        };
 
-		const creationIntervalInput = document.getElementById("creationIntervalInput") as HTMLInputElement;
-		creationIntervalInput.value = (this.streamCreationIntervalMs / 1000.0).toString();
+        const creationIntervalInput = document.getElementById('creationIntervalInput') as HTMLInputElement;
+        creationIntervalInput.value = (this.streamCreationIntervalMs / 1000.0).toString();
 
-		const deletionIntervalInput = document.getElementById("deletionIntervalInput") as HTMLInputElement;
-		deletionIntervalInput.value = (this.streamDeletionIntervalMs / 1000.0).toString();
-	}
+        const deletionIntervalInput = document.getElementById('deletionIntervalInput') as HTMLInputElement;
+        deletionIntervalInput.value = (this.streamDeletionIntervalMs / 1000.0).toString();
+    }
 
+    private setupNumPeersSlider(): void {
+        const nPeersSlider: HTMLInputElement = document.getElementById('nPeersSlider') as HTMLInputElement;
+        nPeersSlider.value = this.maxPeers.toString();
 
-	private setupNumPeersSlider() : void {
-		const nPeersSlider: HTMLInputElement = document.getElementById("nPeersSlider") as HTMLInputElement;
-		nPeersSlider.value = this.maxPeers.toString();
+        const nPeersLabel: HTMLElement = document.getElementById('nPeerLabel');
+        nPeersLabel.innerHTML = this.maxPeers.toString();
 
-		const nPeersLabel: HTMLElement = document.getElementById("nPeerLabel");
-		nPeersLabel.innerHTML = this.maxPeers.toString();
+        nPeersSlider.onchange = (event: Event) => {
+            const inputElem = event.target as HTMLInputElement;
+            const parsedValue = Number.parseInt(inputElem.value);
 
-		nPeersSlider.onchange = (event: Event) => {
-			const inputElem = event.target as HTMLInputElement;
-			const parsedValue = Number.parseInt(inputElem.value);
+            if (!Number.isNaN(parsedValue)) {
+                this.maxPeers = parsedValue;
+                const nPeersLabel: HTMLElement = document.getElementById('nPeerLabel');
+                nPeersLabel.innerHTML = this.maxPeers.toString();
+            }
+        };
+    }
 
-			if (!Number.isNaN(parsedValue)) {
-				this.maxPeers = parsedValue;
-				const nPeersLabel: HTMLElement = document.getElementById("nPeerLabel");
-				nPeersLabel.innerHTML = this.maxPeers.toString();
-			}
-		}
-	}
+    private startStreamCreation(): void {
+        if (this.creationIntervalHandle) {
+            clearInterval(this.creationIntervalHandle);
+        }
 
-	private startStreamCreation() : void {
-		if (this.creationIntervalHandle) {
-			clearInterval(this.creationIntervalHandle);
-		}
+        this.creationIntervalHandle = window.setInterval(() => {
+            if (this.play) {
+                const curNPeers = this.pixelStreamingFrames.length;
+                if (curNPeers >= this.maxPeers) return;
 
-		this.creationIntervalHandle = window.setInterval(() => {
-			if(this.play) {
-				const curNPeers = this.pixelStreamingFrames.length;
-				if(curNPeers >= this.maxPeers) return;
+                const maxPeersToCreate = this.maxPeers - curNPeers;
+                const nPeersToCreate = Math.ceil(Math.random() * maxPeersToCreate);
 
-				const maxPeersToCreate = this.maxPeers - curNPeers;
-				const nPeersToCreate = Math.ceil(Math.random() * maxPeersToCreate);
+                for (let i = 0; i < nPeersToCreate; i++) {
+                    const psFrame = this.createPixelStreamingFrame();
+                    const n = this.pixelStreamingFrames.length;
+                    psFrame.element.id = `PixelStreamingFrame_${n + 1}`;
+                    this.streamsContainer.append(psFrame.element);
+                    this.pixelStreamingFrames.push(psFrame);
+                    this.totalStreams += 1;
+                    this.updateTotalStreams();
+                }
+            }
+        }, this.streamCreationIntervalMs);
+    }
 
-				for(let i = 0; i < nPeersToCreate; i++) {
-					const psFrame = this.createPixelStreamingFrame();
-					const n = this.pixelStreamingFrames.length;
-					psFrame.element.id = `PixelStreamingFrame_${n + 1}`;
-					this.streamsContainer.append(psFrame.element);
-					this.pixelStreamingFrames.push(psFrame);
-					this.totalStreams += 1;
-					this.updateTotalStreams();
-				}
-			}
-		}, this.streamCreationIntervalMs);
-	}
+    private startStreamDeletion(): void {
+        if (this.deletionIntervalHandle) {
+            clearInterval(this.deletionIntervalHandle);
+        }
 
-	private startStreamDeletion() : void {
-		if(this.deletionIntervalHandle) {
-			clearInterval(this.deletionIntervalHandle)
-		}
+        this.deletionIntervalHandle = window.setInterval(() => {
+            if (!this.play) return;
 
-		this.deletionIntervalHandle = window.setInterval(() => {
-			if(!this.play) return;
+            const curNPeers = this.pixelStreamingFrames.length;
+            if (curNPeers === 0) return;
 
-			const curNPeers = this.pixelStreamingFrames.length;
-			if(curNPeers === 0) return;
+            const nPeersToDelete = Math.ceil(Math.random() * curNPeers);
+            for (let i = 0; i < nPeersToDelete; i++) {
+                const psFrame = this.pixelStreamingFrames.shift();
+                // Remove HTML element from DOM
+                psFrame.element.parentNode.removeChild(psFrame.element);
+                // Disconnect Pixel Streaming application so we don't have orphaned WebRTC/WebSocket/PeerConnections
+                psFrame.pixelStreamingApp.stream.disconnect();
+                psFrame?.pixelStreamingApp.stream.webRtcController.destroyPlayer();
+            }
+        }, this.streamDeletionIntervalMs);
+    }
 
-			const nPeersToDelete = Math.ceil(Math.random() * curNPeers);
-			for(let i = 0; i < nPeersToDelete; i++) {
-				const psFrame = this.pixelStreamingFrames.shift();
-				// Remove HTML element from DOM
-				psFrame.element.parentNode.removeChild(psFrame.element);
-				// Disconnect Pixel Streaming application so we don't have orphaned WebRTC/WebSocket/PeerConnections
-				psFrame.pixelStreamingApp.stream.disconnect();
-			}
-		}, this.streamDeletionIntervalMs);
-	}
+    private setupPlayPause(): void {
+        const playPauseBtn = document.getElementById('playPause');
+        playPauseBtn.innerHTML = this.play ? 'Pause' : 'Play';
 
-	private setupPlayPause() : void {
-		const playPauseBtn = document.getElementById("playPause");
-		playPauseBtn.innerHTML = this.play ? "Pause" : "Play";
+        playPauseBtn.onclick = (event: Event) => {
+            this.play = !this.play;
+            playPauseBtn.innerHTML = this.play ? 'Pause' : 'Play';
+        };
+    }
 
-		playPauseBtn.onclick = (event : Event) => {
-			this.play = !this.play;
-			playPauseBtn.innerHTML = this.play ? "Pause" : "Play";
-		}
-	}
+    private createPixelStreamingFrame(): PixelStreamingFrame {
+        const streamFrame = document.createElement('div');
 
-	private createPixelStreamingFrame() : PixelStreamingFrame {
-		const streamFrame = document.createElement("div");
+        const config = new Config();
+        config.setFlagEnabled(Flags.AutoConnect, true);
+        config.setFlagEnabled(Flags.AutoPlayVideo, true);
+        config.setFlagEnabled(Flags.StartVideoMuted, true);
 
-		const config = new Config();
-		config.setFlagEnabled(Flags.AutoConnect, true);
-		config.setFlagEnabled(Flags.AutoPlayVideo, true);
-		config.setFlagEnabled(Flags.StartVideoMuted, true);
+        // Create a Native DOM delegate instance that implements the Delegate interface class
+        const stream = new PixelStreaming(config);
+        const application = new Application({
+            stream,
+            onColorModeChanged: (isLightMode: any) =>
+                PixelStreamingApplicationStyles.setColorMode(isLightMode)
+        });
+        streamFrame.appendChild(application.rootElement);
 
-		// Create a Native DOM delegate instance that implements the Delegate interface class
-		const stream = new PixelStreaming(config);
-		const application = new Application({
-			stream,
-			onColorModeChanged: (isLightMode : any) => PixelStreamingApplicationStyles.setColorMode(isLightMode)
-		});
-		streamFrame.appendChild(application.rootElement);
+        return new PixelStreamingFrame(streamFrame, application);
+    }
 
-		return new PixelStreamingFrame(streamFrame, application);
-	}
-
-	private updateTotalStreams() : void {
-		const nStreamsLabel = document.getElementById("nStreamsLabel");
-		nStreamsLabel.innerHTML = this.totalStreams.toString();
-	}
+    private updateTotalStreams(): void {
+        const nStreamsLabel = document.getElementById('nStreamsLabel');
+        nStreamsLabel.innerHTML = this.totalStreams.toString();
+    }
 }
 
 const tester = new StressTester();
 tester.startStressTest();
+

--- a/Frontend/implementations/typescript/src/stresstest.ts
+++ b/Frontend/implementations/typescript/src/stresstest.ts
@@ -138,7 +138,7 @@ export class StressTester {
                 psFrame.element.parentNode.removeChild(psFrame.element);
                 // Disconnect Pixel Streaming application so we don't have orphaned WebRTC/WebSocket/PeerConnections
                 psFrame.pixelStreamingApp.stream.disconnect();
-                psFrame?.pixelStreamingApp.stream.webRtcController.destroyPlayer();
+                psFrame?.pixelStreamingApp.stream.webRtcController.destroyVideoPlayer();
             }
         }, this.streamDeletionIntervalMs);
     }

--- a/Frontend/library/src/Inputs/MouseController.ts
+++ b/Frontend/library/src/Inputs/MouseController.ts
@@ -58,22 +58,22 @@ export class MouseController implements IInputController {
     }
 
     registerMouseEnterAndLeaveEvents() {
-        const videoElementParent = this.videoPlayer.getVideoParentElement() as HTMLDivElement;
-        videoElementParent.addEventListener('mouseenter', this.onEnterListener);
-        videoElementParent.addEventListener('mouseleave', this.onLeaveListener);
+        const videoElementParent = this.videoPlayer.getVideoParentElement();
+        videoElementParent?.addEventListener('mouseenter', this.onEnterListener);
+        videoElementParent?.addEventListener('mouseleave', this.onLeaveListener);
     }
 
     unregisterMouseEnterAndLeaveEvents() {
-        const videoElementParent = this.videoPlayer.getVideoParentElement() as HTMLDivElement;
-        videoElementParent.removeEventListener('mouseenter', this.onEnterListener);
-        videoElementParent.removeEventListener('mouseleave', this.onLeaveListener);
+        const videoElementParent = this.videoPlayer.getVideoParentElement();
+        videoElementParent?.removeEventListener('mouseenter', this.onEnterListener);
+        videoElementParent?.removeEventListener('mouseleave', this.onLeaveListener);
     }
 
     private onMouseEnter(event: MouseEvent) {
         if (!this.videoPlayer.isVideoReady()) {
             return;
         }
-        this.streamMessageController.toStreamerHandlers.get('MouseEnter')();
+        this.streamMessageController.toStreamerHandlers.get('MouseEnter')?.();
         this.pressMouseButtons(event.buttons, event.x, event.y);
     }
 
@@ -81,7 +81,7 @@ export class MouseController implements IInputController {
         if (!this.videoPlayer.isVideoReady()) {
             return;
         }
-        this.streamMessageController.toStreamerHandlers.get('MouseLeave')();
+        this.streamMessageController.toStreamerHandlers.get('MouseLeave')?.();
         this.releaseMouseButtons(event.buttons, event.x, event.y);
     }
 

--- a/Frontend/library/src/VideoPlayer/VideoPlayer.ts
+++ b/Frontend/library/src/VideoPlayer/VideoPlayer.ts
@@ -70,6 +70,18 @@ export class VideoPlayer {
         window.addEventListener('orientationchange', () => this.onOrientationChange());
     }
 
+    public destroy() {
+        this.videoElement.src = '';
+        this.videoElement.srcObject = null;
+        this.videoElement.remove();
+
+        if (this.audioElement) {
+            this.audioElement.src = '';
+            this.audioElement.srcObject = null;
+            this.audioElement.remove();
+        }
+    }
+
     public setAudioElement(audioElement: HTMLAudioElement): void {
         this.audioElement = audioElement;
     }
@@ -117,8 +129,8 @@ export class VideoPlayer {
      * Get the current context of the html video elements parent
      * @returns - the current context of the video elements parent
      */
-    getVideoParentElement(): HTMLElement {
-        return this.videoElement.parentElement;
+    getVideoParentElement(): HTMLElement | undefined {
+        return this.videoElement.parentElement ?? undefined;
     }
 
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -341,6 +341,14 @@ export class WebRtcPlayerController {
     }
 
     /**
+     * Destroys the player and makes sure resources are freed. This helps to prevent the issue in chrome
+     * where it refuses to make new video players.
+     */
+    destroyPlayer() {
+        this.videoPlayer.destroy();
+    }
+
+    /**
      * Make a request to UnquantizedAndDenormalizeUnsigned coordinates
      * @param x x axis coordinate
      * @param y y axis coordinate

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -341,10 +341,10 @@ export class WebRtcPlayerController {
     }
 
     /**
-     * Destroys the player and makes sure resources are freed. This helps to prevent the issue in chrome
+     * Destroys the video player and makes sure resources are freed. This helps to prevent the issue in chrome
      * where it refuses to make new video players.
      */
-    destroyPlayer() {
+    destroyVideoPlayer() {
         this.videoPlayer.destroy();
     }
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
#344
When running the stress test in chrome, after a duration the streams refuse to play with an error that too many players have been created.

## Solution
The media element needs to clear its source so it can properly be freed. This is done via a new method 'destroyPlayer' that can optionally be called when cleaning up a finished player, such as in the stress tester.
