### PR TITLE
Removed the eslint plugin from the dependencies.

### DIFF
--- a/Common/package.json
+++ b/Common/package.json
@@ -34,8 +34,7 @@
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.4.2",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.0",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
         "@protobuf-ts/runtime": "^2.9.4",

--- a/Extras/JSStreamer/Dockerfile
+++ b/Extras/JSStreamer/Dockerfile
@@ -4,7 +4,6 @@ FROM node:20-bookworm
 ## Maybe something like: docker build -t epicgames/jsstreamer:latest -f ./Extras/JSStreamer/Dockerfile .
 
 WORKDIR /streamer
-COPY /Extras/eslint/plugin-check-copyright ./Extras/eslint/plugin-check-copyright
 COPY /Common ./Common
 COPY /Extras/JSStreamer ./Extras/JSStreamer
 COPY ./package.json ./package.json

--- a/Extras/JSStreamer/package.json
+++ b/Extras/JSStreamer/package.json
@@ -32,8 +32,7 @@
         "webpack": "^5.97.1",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.0",
-        "webpack-node-externals": "^3.0.0",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingcommon-ue5.5": "*"

--- a/Extras/SS_Test/Dockerfile
+++ b/Extras/SS_Test/Dockerfile
@@ -6,7 +6,6 @@ COPY NODE_VERSION ./NODE_VERSION
 COPY package.json ./package.json
 COPY Common/ ./Common
 COPY Extras/SS_Test/ ./Extras/SS_Test
-COPY Extras/eslint/plugin-check-copyright ./Extras/eslint/plugin-check-copyright
 
 RUN npm i
 RUN cd Common && npm i && npm run build

--- a/Extras/SS_Test/package.json
+++ b/Extras/SS_Test/package.json
@@ -22,7 +22,6 @@
         "@types/node": "^20.10.1",
         "@types/ws": "^8.5.10",
         "rimraf": "^5.0.5",
-        "typescript": "^5.3.2",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "typescript": "^5.3.2"
     }
 }

--- a/Frontend/implementations/react/package.json
+++ b/Frontend/implementations/react/package.json
@@ -24,7 +24,6 @@
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "*",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
     }

--- a/Frontend/implementations/typescript/package.json
+++ b/Frontend/implementations/typescript/package.json
@@ -22,7 +22,6 @@
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "*",
-        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5": "*",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5": "*"
     }
 }

--- a/Frontend/library/package.json
+++ b/Frontend/library/package.json
@@ -29,8 +29,7 @@
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.0",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingcommon-ue5.5": "^0.2.9",

--- a/Frontend/ui-library/package.json
+++ b/Frontend/ui-library/package.json
@@ -23,8 +23,7 @@
         "nodemon": "^3.1.9",
         "rimraf": "^6.0.1",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.0",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
         "@babel/runtime": "^7.26.10",

--- a/Signalling/package.json
+++ b/Signalling/package.json
@@ -31,8 +31,7 @@
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.4.2",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.0",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
         "express": "^4.21.2",

--- a/SignallingWebServer/Dockerfile
+++ b/SignallingWebServer/Dockerfile
@@ -4,7 +4,6 @@ FROM node:lts
 WORKDIR /SignallingWebServer
 COPY NODE_VERSION ./NODE_VERSION
 COPY package.json ./package.json
-COPY /Extras/eslint/plugin-check-copyright ./Extras/eslint/plugin-check-copyright
 COPY /Common ./Common
 COPY /Signalling ./Signalling
 COPY /SignallingWebServer ./SignallingWebServer

--- a/SignallingWebServer/package.json
+++ b/SignallingWebServer/package.json
@@ -24,8 +24,7 @@
         "eslint-plugin-tsdoc": "^0.4.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.0",
-        "@epicgames-ps/eslint-plugin-check-copyright": "*"
+        "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingsignalling-ue5.5": "*",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@
 import eslint from '@eslint/js';
 import prettierPluginRecommended from 'eslint-plugin-prettier/recommended';
 import tseslint from 'typescript-eslint';
-import checkCopyrightPlugin from '@epicgames-ps/eslint-plugin-check-copyright'
+import checkCopyrightPlugin from './Extras/eslint/plugin-check-copyright/index.js'
 
 export default tseslint.config(
     eslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,9 @@
                 "Extras/FrontendTests",
                 "Extras/MinimalStreamTester",
                 "Extras/SS_Test",
-                "Extras/mediasoup-sdp-bridge",
-                "Extras/eslint/plugin-check-copyright"
+                "Extras/mediasoup-sdp-bridge"
             ],
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "eslint": "^9.22.0",
                 "lint-staged": "^15.3.0",
                 "pre-commit": "^1.0.10",
@@ -39,7 +37,6 @@
                 "ws": "^8.18.0"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@eslint/js": "^9.20.0",
                 "@protobuf-ts/plugin": "^2.9.4",
                 "concurrently": "^9.1.2",
@@ -142,6 +139,7 @@
         "Extras/eslint/plugin-check-copyright": {
             "name": "@epicgames-ps/eslint-plugin-check-copyright",
             "version": "1.0.0",
+            "extraneous": true,
             "license": "MIT",
             "devDependencies": {
                 "eslint": "^9.20.0"
@@ -185,7 +183,6 @@
                 "@epicgames-ps/lib-pixelstreamingcommon-ue5.5": "*"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "copy-webpack-plugin": "^12.0.2",
                 "eslint": "^9.20.1",
                 "eslint-config-prettier": "^10.0.1",
@@ -891,7 +888,6 @@
                 "ws": "^8.17.1"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@types/assert": "^1.5.10",
                 "@types/node": "^20.10.1",
                 "@types/ws": "^8.5.10",
@@ -919,7 +915,6 @@
             "name": "@epicgames-ps/react-pixelstreamingfrontend-react-ue5.5",
             "version": "0.0.1",
             "dependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "*",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0"
@@ -939,7 +934,6 @@
             "name": "@epicgames-ps/reference-pixelstreamingfrontend-ue5.5",
             "version": "0.0.1",
             "dependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "*",
                 "@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5": "*"
             },
@@ -960,7 +954,6 @@
                 "sdp": "^3.2.0"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@eslint/js": "^9.20.0",
                 "@types/jest": "^29.5.14",
                 "@types/webxr": "^0.5.21",
@@ -986,7 +979,6 @@
                 "jss-plugin-global": "^10.10.0"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@eslint/js": "^9.20.0",
                 "@types/webxr": "^0.5.21",
                 "eslint": "^9.20.0",
@@ -2157,10 +2149,6 @@
             "engines": {
                 "node": ">=14.17.0"
             }
-        },
-        "node_modules/@epicgames-ps/eslint-plugin-check-copyright": {
-            "resolved": "Extras/eslint/plugin-check-copyright",
-            "link": true
         },
         "node_modules/@epicgames-ps/js-streamer": {
             "resolved": "Extras/JSStreamer",
@@ -18318,7 +18306,6 @@
                 "ws": "^8.18.0"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@eslint/js": "^9.20.0",
                 "@types/express": "^5.0.0",
                 "@types/ws": "^8.5.14",
@@ -18433,7 +18420,6 @@
                 "jsonc": "^2.0.0"
             },
             "devDependencies": {
-                "@epicgames-ps/eslint-plugin-check-copyright": "*",
                 "@eslint/js": "^9.20.0",
                 "@types/express": "^5.0.0",
                 "eslint": "^9.20.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
         "Extras/FrontendTests",
         "Extras/MinimalStreamTester",
         "Extras/SS_Test",
-        "Extras/mediasoup-sdp-bridge",
-        "Extras/eslint/plugin-check-copyright"
+        "Extras/mediasoup-sdp-bridge"
     ],
     "private": true,
     "scripts": {
@@ -28,7 +27,6 @@
         "pre-commit-lint"
     ],
     "devDependencies": {
-        "@epicgames-ps/eslint-plugin-check-copyright": "*",
         "eslint": "^9.22.0",
         "typescript-eslint": "^8.26.1",
         "lint-staged": "^15.3.0",


### PR DESCRIPTION
## Problem statement:
The lint plugin shouldn't be required for anything but linting. Having it in the dependencies shouldn't be needed.

## Solution
The lint config now directly imports the plugin by path rather than package name.
