### PR TITLE
[UE5.5] Merge pull request #553 from mcottontensor/node_types_fix

### DIFF
--- a/Common/package.json
+++ b/Common/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {
         "@eslint/js": "^9.20.0",
         "@protobuf-ts/plugin": "^2.9.4",
+        "@types/node": "^22.13.17",
         "concurrently": "^9.1.2",
         "eslint": "^9.20.0",
         "eslint-config-prettier": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
             "devDependencies": {
                 "@eslint/js": "^9.20.0",
                 "@protobuf-ts/plugin": "^2.9.4",
+                "@types/node": "^22.13.17",
                 "concurrently": "^9.1.2",
                 "eslint": "^9.20.0",
                 "eslint-config-prettier": "^10.0.1",
@@ -80,6 +81,16 @@
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
+            }
+        },
+        "Common/node_modules/@types/node": {
+            "version": "22.14.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+            "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
             }
         },
         "Common/node_modules/glob": {
@@ -220,6 +231,13 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "Common/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "Extras/FrontendTests": {
             "name": "frontend-tests",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [Merge pull request #553 from mcottontensor/node_types_fix](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/553)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)