### PR TITLE
Moved frontend library from a peer dependency to a normal dependency in ui-library

### DIFF
--- a/.changeset/shaky-boats-unite.md
+++ b/.changeset/shaky-boats-unite.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5': minor
+---
+
+Frontend library is no longer a peer dependency but instead now a normal dependency.

--- a/Frontend/ui-library/package.json
+++ b/Frontend/ui-library/package.json
@@ -26,13 +26,11 @@
         "typescript-eslint": "^8.24.0"
     },
     "dependencies": {
+        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "^1.0.2",
         "@babel/runtime": "^7.26.10",
         "jss": "^10.10.0",
         "jss-plugin-camel-case": "^10.10.0",
         "jss-plugin-global": "^10.10.0"
-    },
-    "peerDependencies": {
-        "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "^1.0.2"
     },
     "repository": {
         "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -872,6 +872,7 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.26.10",
+                "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "^1.0.2",
                 "jss": "^10.10.0",
                 "jss-plugin-camel-case": "^10.10.0",
                 "jss-plugin-global": "^10.10.0"
@@ -884,9 +885,6 @@
                 "rimraf": "^6.0.1",
                 "typescript": "^5.7.3",
                 "typescript-eslint": "^8.24.0"
-            },
-            "peerDependencies": {
-                "@epicgames-ps/lib-pixelstreamingfrontend-ue5.5": "^1.0.2"
             }
         },
         "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
As per title.

Tested and the bundle size is no different with it as a peer dep or a normal dep.