### PR TITLE
[UE5.5] Removed sparse checkout from sfu container action. It just causes issues (#584)

### DIFF
--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-            sparse-checkout: 'SFU'
-            sparse-checkout-cone-mode: false
 
       - name: Obtain the UE version from the branch name
         id: extract-version


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [Removed sparse checkout from sfu container action. It just causes issues (#584)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/584)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)