### PR TITLE
Fixing module resolution within IDEs

### DIFF
--- a/Common/tsconfig.cjs.json
+++ b/Common/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs"
+        "module": "commonjs",
+        "moduleResolution": "node10"
     }
 }

--- a/Common/tsconfig.json
+++ b/Common/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitReturns": true,
         "noPropertyAccessFromIndexSignature": true,
         "declaration": true,
-        "declarationDir": "./dist/types"
+        "declarationDir": "./dist/types",
+        "moduleResolution": "bundler" // helps IDEs
     },
     "include": ["./src/*.ts"],
     "typedocOptions": {

--- a/Frontend/implementations/typescript/tsconfig.cjs.json
+++ b/Frontend/implementations/typescript/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs"
+        "module": "commonjs",
+        "moduleResolution": "node10"
     }
 }

--- a/Frontend/implementations/typescript/tsconfig.json
+++ b/Frontend/implementations/typescript/tsconfig.json
@@ -11,7 +11,8 @@
         "noImplicitReturns": true,
         "noPropertyAccessFromIndexSignature": true,
         "declaration": true,
-        "declarationDir": "./dist/types"
+        "declarationDir": "./dist/types",
+        "moduleResolution": "bundler" // helps IDEs
     },
     "lib": ["ES6"],
     "include": ["./src/*.ts"]

--- a/Frontend/library/tsconfig.cjs.json
+++ b/Frontend/library/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs"
+        "module": "commonjs",
+        "moduleResolution": "node10"
     }
 }

--- a/Frontend/library/tsconfig.json
+++ b/Frontend/library/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitReturns": true,
         "noPropertyAccessFromIndexSignature": true,
         "declaration": true,
-        "declarationDir": "./dist/types"
+        "declarationDir": "./dist/types",
+        "moduleResolution": "bundler" // helps IDEs
     },
     "lib": ["ES6"],
     "include": ["./src/**/*.ts"],

--- a/Frontend/ui-library/tsconfig.cjs.json
+++ b/Frontend/ui-library/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs"
+        "module": "commonjs",
+        "moduleResolution": "node10"
     }
 }

--- a/Frontend/ui-library/tsconfig.json
+++ b/Frontend/ui-library/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitReturns": true,
         "noPropertyAccessFromIndexSignature": true,
         "declaration": true,
-        "declarationDir": "./dist/types"
+        "declarationDir": "./dist/types",
+        "moduleResolution": "bundler"
     },
     "lib": ["es2015"],
     "include": ["./src/*.ts"],

--- a/Signalling/tsconfig.cjs.json
+++ b/Signalling/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs"
+        "module": "commonjs",
+        "moduleResolution": "node10"
     }
 }

--- a/Signalling/tsconfig.json
+++ b/Signalling/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitReturns": true,
         "noPropertyAccessFromIndexSignature": true,
         "declaration": true,
-        "declarationDir": "./dist/types"
+        "declarationDir": "./dist/types",
+        "moduleResolution": "bundler" // helps IDEs
     },
     "include": ["./src/*.ts"],
     "typedocOptions": {


### PR DESCRIPTION
## Problem statement:
I noticed recently that my IDE was complaining about not finding certain imports which was breaking a lot of intellisense stuff. Turns out if was related to recent tsconfig changes.

## Solution
In the base tsconfig of each project I have changed the moduleResolution to 'bundler' which allows the IDE to properly resolve all imports since it only looks at the base tsconfig.json and not the module specific cjs or esm versions.
Additionally I have set moduleResolution to 'node10' in the cjs configs since this is the default setting for cjs modules. The esm versions already had the proper setting. This ensures that the bundler setting is properly changed in each actual build.
