### PR TITLE
Fixing path setup in the windows platform scripts.

### DIFF
--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -140,8 +140,13 @@ if exist node\ (
   set INSTALL_DEPS=1
 )
 
+rem NOTE: We want to use our NodeJS (not system NodeJS!) to build the web frontend files.
+rem Save our current directory (the NodeJS dir) in a variable
+set NODE_DIR=%SCRIPT_DIR%node
+set PATH=%NODE_DIR%;%PATH%
+
 rem Print node version
-FOR /f %%A IN ('node\node.exe -v') DO set NODE_VERSION=%%A
+FOR /f %%A IN ('node.exe -v') DO set NODE_VERSION=%%A
 echo Node version: %NODE_VERSION%
 popd
 
@@ -189,10 +194,6 @@ exit /b
 rem Start in the repo dir
 pushd %SCRIPT_DIR%..\..\..\
 
-rem NOTE: We want to use our NodeJS (not system NodeJS!) to build the web frontend files.
-rem Save our current directory (the NodeJS dir) in a variable
-set NODE_DIR=%SCRIPT_DIR%node
-
 IF "%FRONTEND_DIR%"=="" (
     set FRONTEND_DIR="%SCRIPT_DIR%..\..\www"
 ) else (
@@ -210,7 +211,6 @@ IF NOT exist "%FRONTEND_DIR%" (
     set BUILD_FRONTEND=1
 )
 
-set PATH=%NODE_DIR%;%PATH%
 
 IF "%BUILD_FRONTEND%"=="1" (
     rem We could replace this all with a single npm script that does all this. we do have several build-all scripts already


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
On fresh windows installs, the platform scripts were giving cryptic failures. Issues with npm cleanup not being able to delete certain paths etc.

## Solution
The real problem is that we weren't setting the path variable to the specific node installation we wanted to use. In some instances we were calling the node executable by full path but within the tooling itself the executable was expected to be in the path and so things basically failed in weird ways.
