### PR TITLE
Update cirrus to function with newer infra versions

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -368,7 +368,6 @@ streamerServer.on('connection', function (ws, req) {
 				}
 			} else {
 				console.error(`unsupported Streamer message type: ${msg.type}`);
-				streamer.close(1008, 'Unsupported message type');
 			}
 		} catch(err) {
 			console.error(`ERROR: ws.on message error: ${err.message}`);
@@ -461,9 +460,10 @@ playerServer.on('connection', function (ws, req) {
 			sendMessageToStreamer(msg);
 		} else if (msg.type == 'stats') {
 			console.log(`player ${playerId}: stats\n${msg.data}`);
+		} else if (msg.type == 'ping') {
+			ws.send(JSON.stringify({ type: 'pong', time: msg.time}));
 		} else {
 			console.error(`player ${playerId}: unsupported message type: ${msg.type}`);
-			ws.close(1008, 'Unsupported message type');
 			return;
 		}
 	});


### PR DESCRIPTION
## Relevant components:
- [X] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
4.27 Cirrus is unable to work with newer infra versions due to them sending previously unrecognized message types. When an unknown message is received, cirrus forcefully closes the ws (doh!). Additionally, the new frontend versions rely on a ping-pong health check so cirrus needs to send pong back to the frontend to keep the ws connection alive.

## Solution
- Don't forcefully close ws connections on unknown message types
- Send pong back to frontend