### PR TITLE
Fixes "tsc: not found" for "SignallingWebServer/platform_scripts/bash…

### DIFF
--- a/SignallingWebServer/Dockerfile
+++ b/SignallingWebServer/Dockerfile
@@ -10,6 +10,7 @@ COPY /SignallingWebServer ./SignallingWebServer
 COPY /Frontend ./Frontend
 # Install the dependencies for the signalling server and build the frontend
 RUN apt-get update
+RUN npm install typescript
 RUN SignallingWebServer/platform_scripts/bash/setup.sh --build
 
 # Expose TCP ports 80 and 443 for player WebSocket connections and web server HTTP(S) access


### PR DESCRIPTION
…/setup.sh --build"

fixes:
```
 => [ 2/10] WORKDIR /SignallingWebServer                                                                                                                                                0.1s
 => [ 3/10] COPY NODE_VERSION ./NODE_VERSION                                                                                                                                            0.0s
 => [ 4/10] COPY package.json ./package.json                                                                                                                                            0.0s
 => [ 5/10] COPY /Common ./Common                                                                                                                                                       0.0s
 => [ 6/10] COPY /Signalling ./Signalling                                                                                                                                               0.0s
 => [ 7/10] COPY /SignallingWebServer ./SignallingWebServer                                                                                                                             0.6s
 => [ 8/10] COPY /Frontend ./Frontend                                                                                                                                                   0.0s
 => [ 9/10] RUN apt-get update                                                                                                                                                          2.4s
 => ERROR [10/10] RUN SignallingWebServer/platform_scripts/bash/setup.sh --build                                                                                                        0.5s
------                                                                                                                                                                                       
 > [10/10] RUN SignallingWebServer/platform_scripts/bash/setup.sh --build:                                                                                                                   
0.061 Checking Pixel Streaming Server dependencies.                                                                                                                                          
0.065 Checking for required node install                                                                                                                                                     
0.067 Current version: 22.14.0 checking >= 22.14.0                                                                                                                                           
0.067 node is installed.                                                                                                                                                                     
0.068 Testing /SignallingWebServer/SignallingWebServer/platform_scripts/bash/../../www
0.068 Building Typescript Frontend.
0.403 
0.403 > @epicgames-ps/lib-pixelstreamingfrontend-ue5.5@1.1.0 build:cjs
0.403 > tsc --project tsconfig.cjs.json
0.403 
0.407 sh: 1: tsc: not found
0.411 npm error Lifecycle script `build:cjs` failed with error:
0.411 npm error code 127
0.411 npm error path /SignallingWebServer/Frontend/library
0.411 npm error workspace @epicgames-ps/lib-pixelstreamingfrontend-ue5.5@1.1.0
0.411 npm error location /SignallingWebServer/Frontend/library
0.412 npm error command failed
0.412 npm error command sh -c tsc --project tsconfig.cjs.json
------
Dockerfile:13
--------------------
  11 |     # Install the dependencies for the signalling server and build the frontend
  12 |     RUN apt-get update
  13 | >>> RUN SignallingWebServer/platform_scripts/bash/setup.sh --build
  14 |     
  15 |     # Expose TCP ports 80 and 443 for player WebSocket connections and web server HTTP(S) access
--------------------
ERROR: failed to solve: process "/bin/sh -c SignallingWebServer/platform_scripts/bash/setup.sh --build" did not complete successfully: exit code: 127
```

## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU
