### PR TITLE
Fixing dependency issues that arise in the docker image.

### DIFF
--- a/SignallingWebServer/Dockerfile
+++ b/SignallingWebServer/Dockerfile
@@ -4,6 +4,7 @@ FROM node:lts
 WORKDIR /SignallingWebServer
 COPY NODE_VERSION ./NODE_VERSION
 COPY package.json ./package.json
+COPY package-lock.json ./package-lock.json
 COPY /Common ./Common
 COPY /Signalling ./Signalling
 COPY /SignallingWebServer ./SignallingWebServer


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Occasionally when building the signalling docker image, package issues could randomly show up.

## Solution
This was simply caused by the fact that the package-lock file was not copied into the image. This change copies that file in which locks the packages to known working configurations.
