### PR TITLE
Fixing path issues in platform_scripts

### DIFF
--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -20,6 +20,20 @@ jobs:
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
+  run-multiple-script-linux:
+    # tests running the scripts after being setup. catches issues where environment changes from installing to installed
+    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Launch and query signalling server using the REST API
+        working-directory: SignallingWebServer
+        run: |
+          ./platfirn_scripts/bash/setup.sh
+          ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
+          curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
+
   run-script-macos:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
     runs-on: macos-latest

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -20,45 +20,12 @@ jobs:
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
-  run-multiple-script-linux:
-    # tests running the scripts after being setup. catches issues where environment changes from installing to installed
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-      - name: Test node
-        run: node --version
-      - name: Setup the dependencies for the signalling server
-        working-directory: SignallingWebServer
-        run: ./platform_scripts/bash/setup.sh
-      - name: Launch and query signalling server using the REST API
-        working-directory: SignallingWebServer
-        run: |
-          ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
-          curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
-
   run-script-macos:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
     runs-on: macos-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
-      - name: Launch and query signalling server using the REST API
-        working-directory: SignallingWebServer
-        run: |
-          ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
-          curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
-
-  run-multiple-script-macos:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
-    runs-on: macos-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-      - name: Setup the dependencies for the signalling server
-        working-directory: SignallingWebServer
-        run: ./platform_scripts/bash/setup.sh
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
@@ -76,19 +43,3 @@ jobs:
         run: |
           Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--rest_api","--player_port 999"
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
-
-  run-multiple-script-windows:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
-    runs-on: windows-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-      - name: Setup the dependencies for the signalling server
-        working-directory: SignallingWebServer
-        run: ./platform_scripts/cmd/setup.bat
-      - name: Launch and query signalling server using the REST API
-        working-directory: SignallingWebServer
-        run: |
-          Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--rest_api","--player_port 999"
-          curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
-

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -27,10 +27,14 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Test node
+        run: node --version
+      - name: Setup the dependencies for the signalling server
+        working-directory: SignallingWebServer
+        run: ./platform_scripts/bash/setup.sh
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          ./platform_scripts/bash/setup.sh
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
@@ -52,10 +56,12 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Setup the dependencies for the signalling server
+        working-directory: SignallingWebServer
+        run: ./platform_scripts/bash/setup.sh
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          ./platform_scripts/bash/setup.sh
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
@@ -77,10 +83,12 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Setup the dependencies for the signalling server
+        working-directory: SignallingWebServer
+        run: ./platform_scripts/cmd/setup.bat
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          Start-Process -NoNewWindow ".\platform_scripts\cmd\setup.bat"
           Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--rest_api","--player_port 999"
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          ./platfirn_scripts/bash/setup.sh
+          ./platforn_scripts/bash/setup.sh
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -46,6 +46,19 @@ jobs:
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
+  run-multiple-script-macos:
+    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Launch and query signalling server using the REST API
+        working-directory: SignallingWebServer
+        run: |
+          ./platform_scripts/bash/setup.sh
+          ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
+          curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
+
   run-script-windows:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
     runs-on: windows-latest
@@ -55,6 +68,19 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
+          Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--rest_api","--player_port 999"
+          curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
+
+  run-multiple-script-windows:
+    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Launch and query signalling server using the REST API
+        working-directory: SignallingWebServer
+        run: |
+          Start-Process -NoNewWindow ".\platform_scripts\cmd\setup.bat"
           Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--rest_api","--player_port 999"
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          ./platforn_scripts/bash/setup.sh
+          ./platform_scripts/bash/setup.sh
           ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -169,10 +169,8 @@ function setup_node() {
     # navigate to project root
     pushd "${SCRIPT_DIR}/../../.." > /dev/null
 
-    node_version=""
-    if [[ -f "${SCRIPT_DIR}/node/bin/node" ]]; then
-        node_version=$("${SCRIPT_DIR}/node/bin/node" --version)
-    fi
+    PATH="${SCRIPT_DIR}/node/bin:$PATH"
+    node_version=$(node --version)
 
     node_url=""
     if [ "$(uname)" == "Darwin" ]; then
@@ -195,7 +193,6 @@ function setup_node() {
 
     if [ $? -eq 1 ] || [ "$INSTALL_DEPS" == "1" ]; then
         echo "Installing dependencies..."
-        PATH="${SCRIPT_DIR}/node/bin:$PATH"
         "${NPM}" install
     fi
 

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -115,6 +115,7 @@ function check_version() { #current_version #min_version
 function check_and_install() { #dep_name #get_version_string #version_min #install_command
 	local is_installed=0
 
+    echo PATH=$PATH
 	echo "Checking for required $1 install"
 
 	local current=$(echo $2 | sed -E 's/[^0-9.]//g')

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -169,8 +169,13 @@ function setup_node() {
     # navigate to project root
     pushd "${SCRIPT_DIR}/../../.." > /dev/null
 
+    # setup the path so we're using our node. required when calling npm
     PATH="${SCRIPT_DIR}/node/bin:$PATH"
-    node_version=$(node --version)
+
+    node_version=""
+    if [[ -f "${SCRIPT_DIR}/node/bin/node" ]]; then
+        node_version=$("${SCRIPT_DIR}/node/bin/node" --version)
+    fi
 
     node_url=""
     if [ "$(uname)" == "Darwin" ]; then
@@ -186,7 +191,7 @@ function setup_node() {
     else
         node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
     fi
-    check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
+    check_and_install "${SCRIPT_DIR}/node/bin/node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
                                                                 && tar -xf node.tar.xz
                                                                 && rm node.tar.xz
                                                                 && mv node-v*-*-* \"${SCRIPT_DIR}/node\""

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -115,7 +115,6 @@ function check_version() { #current_version #min_version
 function check_and_install() { #dep_name #get_version_string #version_min #install_command
 	local is_installed=0
 
-    echo PATH=$PATH
 	echo "Checking for required $1 install"
 
 	local current=$(echo $2 | sed -E 's/[^0-9.]//g')


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
The environment when installing node can differ from the environment when node is already installed leading to some issues where the correct node executable cannot be found.

## Solution
Making sure the correct node path is always in the path environment.
