### PR TITLE
Better handling of node in Linux scripts.

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
-  "repoOwner": "EpicGamesExt",
-  "repoName": "PixelStreamingInfrastructure",
-  "targetBranchChoices": ["master", "UE5.2", "UE5.3", "UE5.4", "UE5.5"],
-  "autoMerge": true,
-  "autoMergeMethod": "squash"
+    "repoOwner": "EpicGamesExt",
+    "repoName": "PixelStreamingInfrastructure",
+    "targetBranchChoices": ["master", "UE5.2", "UE5.3", "UE5.4", "UE5.5", "LatencyTest"],
+    "autoMerge": true,
+    "autoMergeMethod": "squash"
 }

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -168,7 +168,6 @@ function setup_node() {
         node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
     fi
 
-    node_version="101.1.1" #TEMP debug testing
     check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
                                                                 && tar -xf node.tar.xz
                                                                 && rm node.tar.xz

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 NODE_VERSION=$(<"${SCRIPT_DIR}/../../../NODE_VERSION")
-NPM="${SCRIPT_DIR}/node/bin/npm"
+NPM="npm"
 
 # Prints the arguments and their descriptions to the console
 function print_usage() {

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -168,6 +168,7 @@ function setup_node() {
         node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
     fi
 
+    node_version="1.1.1" #TEMP debug testing
     check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
                                                                 && tar -xf node.tar.xz
                                                                 && rm node.tar.xz

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -184,6 +184,10 @@ function setup_node() {
         npm install
     fi
 
+    # log node version for audits
+    echo "Using node version: $(node --version)"
+    echo "Using NPM version: $(npm --version)"
+
     popd > /dev/null
 }
 

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -168,7 +168,7 @@ function setup_node() {
         node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
     fi
 
-    node_version="1.1.1" #TEMP debug testing
+    node_version="101.1.1" #TEMP debug testing
     check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
                                                                 && tar -xf node.tar.xz
                                                                 && rm node.tar.xz

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -148,9 +148,6 @@ function setup_node() {
     # navigate to project root
     pushd "${SCRIPT_DIR}/../../.." > /dev/null
 
-    # setup the path so we're using our node. required when calling npm
-    # PATH="${SCRIPT_DIR}/node/bin:$PATH"
-
     local node_version=$("node" --version)
 
     local node_url=""
@@ -378,7 +375,6 @@ function start_wilbur() {
     echo "Starting wilbur signalling server use ctrl-c to exit"
     echo "----------------------------------"
     
-    echo "sudo env \"PATH=$PATH\" npm start -- ${SERVER_ARGS}"
     start_process "sudo env \"PATH=$PATH\" npm start -- ${SERVER_ARGS}"
 
     popd > /dev/null


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
A few issues:
- The handling of node sometimes causes issues on some environments.
- The semver comparison function does not work on mac.

## Solution
For the node installations, we now just check whatever node is installed. If it's greater or equal to our requirements we do nothing. Otherwise we install node in our local location. If we installed node, then we update PATH to point to the new location.
If node_modules doesnt exist or package-lock is newer than the directory, we install dependencies, otherwise we assume they're up to date.
Additionally I've also added a printout of the node and npm versions used in the script.
I've removed the weird NPM variable that was used to point to the specific npm version. Since we now properly update the path it should not be needed. Also, the way we call sudo now should also allow the correct path variable to carry over to the new environment.
The version check function also now uses a simplified version utilizing 'sort -V' which is designed to sort version numbers. This should work across OSs like Linux and Mac.
