### PR TITLE
Fixing a small issue with how path was setup previously.

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -145,6 +145,9 @@ function setup_node() {
 
     popd > /dev/null
 
+    # setup path with our possibly locally installed node
+    PATH="${SCRIPT_DIR}/node/bin:$PATH"
+
     # navigate to project root
     pushd "${SCRIPT_DIR}/../../.." > /dev/null
 
@@ -169,11 +172,6 @@ function setup_node() {
                                                                 && tar -xf node.tar.xz
                                                                 && rm node.tar.xz
                                                                 && mv node-v*-*-* \"${SCRIPT_DIR}/node\""
-
-    if [ $? -eq 1 ]; then
-        # installed node, point PATH to it
-        PATH="${SCRIPT_DIR}/node/bin:$PATH"
-    fi
 
     # if node_modules doesnt exist or the package-lock file is newer than node_modules, install deps
     if [ ! -d node_modules ] || [ ../package-lock.json -nt node_modules ] || [ "$INSTALL_DEPS" == "1" ]; then


### PR DESCRIPTION

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
If the node install was installed locally previously the script would not pick that up and try to install again. It would fail because the directory already exists and then the path would not get properly setup for the local install of node.

## Solution
This change sets PATH to point to the local install anyway. If it doesn't exist it doesn't matter, if it does exist we use the local install.
