### PR TITLE
feat: reverse proxy configuration

### DIFF
--- a/.changeset/red-turtles-cross.md
+++ b/.changeset/red-turtles-cross.md
@@ -1,0 +1,12 @@
+---
+'@epicgames-ps/wilbur': minor
+---
+
+Adds command line options to wilbur to allow for configuring the reverse proxy:
+
+--reverse-proxy Enables reverse proxy mode. This will
+trust the X-Forwarded-For header.
+(default: false)
+--reverse-proxy-num-proxies <number> Sets the number of proxies to trust.
+This is used to calculate the real
+client IP address. (default: 1)

--- a/SignallingWebServer/config.json
+++ b/SignallingWebServer/config.json
@@ -14,6 +14,8 @@
 	"ssl_cert_path": "certificates/client-cert.pem",
 	"https_redirect": true,
 	"rest_api": false,
+	"reverse_proxy": false,
+	"reverse_proxy_num_proxies": 1,
 	"peer_options": "",
 	"log_config": true,
 	"stdin": false,

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -147,9 +147,16 @@ program
             .argParser(JSON.parse)
             .default(config_file.peer_options || '')
     )
-    .option('--reverse-proxy', 'Enables reverse proxy mode. This will trust the X-Forwarded-For header.', config_file.reverse_proxy || false)
+    .option(
+        '--reverse-proxy',
+        'Enables reverse proxy mode. This will trust the X-Forwarded-For header.',
+        config_file.reverse_proxy || false
+    )
     .addOption(
-        new Option('--reverse-proxy-num-proxies <number>', 'Sets the number of proxies to trust. This is used to calculate the real client IP address.')
+        new Option(
+            '--reverse-proxy-num-proxies <number>',
+            'Sets the number of proxies to trust. This is used to calculate the real client IP address.'
+        )
             .implies({ reverse_proxy: true })
             .default(config_file.reverse_proxy_num_proxies || 1)
     )

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -147,6 +147,12 @@ program
             .argParser(JSON.parse)
             .default(config_file.peer_options || '')
     )
+    .option('--reverse-proxy', 'Enables reverse proxy mode. This will trust the X-Forwarded-For header.', config_file.reverse_proxy || false)
+    .addOption(
+        new Option('--reverse-proxy-num-proxies <number>', 'Sets the number of proxies to trust. This is used to calculate the real client IP address.')
+            .implies({ reverse_proxy: true })
+            .default(config_file.reverse_proxy_num_proxies || 1)
+    )
     .option(
         '--log_config',
         'Will print the program configuration on startup.',
@@ -197,6 +203,9 @@ if (options.log_config) {
 }
 
 const app = express();
+if (options.reverse_proxy) {
+    app.set('trust proxy', options.reverse_proxy_num_proxies);
+}
 
 const serverOpts: IServerConfig = {
     streamerPort: options.streamer_port,


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When using the pixel streaming webserver behind a reverse proxy the X-Forwarded-For header is not trusted by default in the express application and you will get a message on the console like this:
```
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users. See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/ for more information.
```

## Solution
Add two command line options to configure this value and set it according to the error messages referenced document when the arguments are passed.

## Documentation
From --help:
```
  --reverse-proxy                       Enables reverse proxy mode. This will
                                        trust the X-Forwarded-For header.
                                        (default: false)
  --reverse-proxy-num-proxies <number>  Sets the number of proxies to trust.
                                        This is used to calculate the real
                                        client IP address. (default: 1)
```

## Test Plan and Compatibility
I built a docker image with this change and used it for my pixel streaming build preview server.  I ran it without an entrypoint override to supply these new arguments and with an entrypoint override to ensure that the error message no longer appears.  Works as expected.
