### PR TITLE
Fixing windows SFU platform scripts.

### DIFF
--- a/SFU/platform_scripts/cmd/setup_node.bat
+++ b/SFU/platform_scripts/cmd/setup_node.bat
@@ -6,7 +6,7 @@
 pushd "%~dp0"
 
 @Rem Name and version of node that we are downloading
-set /p NodeVersion=<"%SCRIPT_DIR%/../../../NODE_VERSION"
+set /p NodeVersion=<"../../../NODE_VERSION"
 SET NodeName=node-%NodeVersion%-win-x64
 
 @Rem Look for a node directory next to this script


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
Running the SFU platform scripts on windows results in an error.

## Solution
There is a environment variable used in the platform scripts that is never setup. This leads to the script referring to a location that doesn't exist. The variable is not actually needed so removing it fixes the issue.
