### PR TITLE
Bringing over github action changes from 5.6

### DIFF
--- a/.github/workflows/changesets-publish-npm-packages.yml
+++ b/.github/workflows/changesets-publish-npm-packages.yml
@@ -37,9 +37,9 @@ jobs:
             fi
           done
           # change the list into a json list
-          publish_json_list=[$(IFS=,; echo "${to_publish[*]}")]
+          publish_json_list="{\"count\": ${#to_publish[@]}, \"list\": [$(IFS=,; echo "${to_publish[*]}")]}"
           echo "matrix=$publish_json_list" >> $GITHUB_OUTPUT
-
+          echo $publish_json_list | jq
 
   # actually publishes the npm package.
   publish:
@@ -47,11 +47,11 @@ jobs:
     needs: fetch-package-info
     permissions:
       contents: write
-    if: ${{ fromJSON(needs.fetch-package-info.outputs.matrix).length > 0 }}
+    if: ${{ fromJSON(needs.fetch-package-info.outputs.matrix).count > 0 }}
     strategy:
       max-parallel: 1
       matrix:
-        package: ${{ fromJson(needs.fetch-package-info.outputs.matrix) }}
+        package: ${{ fromJson(needs.fetch-package-info.outputs.matrix).list }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -12,8 +12,15 @@ env:
 jobs:
   build-using-public-deps:
     runs-on: ubuntu-latest
-    outputs:
-      continue: ${{ steps.set_output.outputs.continue }}
+    strategy:
+      matrix:
+        package: 
+          - Common
+          - Signalling
+          - Frontend/library
+          - Frontend/ui-library
+          - Frontend/implementations/typescript
+
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
@@ -30,36 +37,13 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Remove NPM workspaces
-      run: rm package.json && rm package-lock.json
+      run: rm package.json
 
     # Not linting or testing because some of those tools require the
     # workspace dependencies. eg. eslint and its plugins.
     
-    - name: Build signalling using published packages only
-      if: always()
-      working-directory: Signalling
-      run: npm install && npm run build
-
-    - name: Build Wilbur using published packages only
-      if: always()
-      working-directory: SignallingWebServer
-      run: npm install && npm run build
-
-    - name: Build Frontend/library using published packages only
-      if: always()
-      working-directory: Frontend/library
-      run: npm install && npm run build
-
-    - name: Build Frontend/ui-library using published packages only
-      if: always()
-      working-directory: Frontend/ui-library
-      run: npm install && npm run build
-
-    - name: Build Frontend/implementations/typescript using published packages only
-      if: always()
-      working-directory: Frontend/implementations/typescript
-      run: npm install && npm run build
-
-    - id: set_output
-      run: echo "continue=true" >> $GITHUB_ENV
-
+    - name: Build ${{ matrix.package }}
+      working-directory: ${{ matrix.package }}
+      run: |
+        npm install
+        npm run build

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.9.0
         with:
-          args: --exclude 'localhost' --exclude 'github.com/EpicGames/UnrealEngine' --exclude '.png' --exclude '.jpg' --exclude-path 'SFU/mediasoup-sdp-bridge/README.md' './**/*.md'
+          args: --github-token ${{ secrets.WORKFLOW_TOKEN }} --exclude 'localhost' --exclude 'github.com/EpicGames/UnrealEngine' --exclude '.png' --exclude '.jpg' --exclude-path 'SFU/mediasoup-sdp-bridge/README.md' './**/*.md'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -1,7 +1,13 @@
 name: Check health of streaming
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/healthcheck-streaming.yml"
   pull_request:
     paths:
       - ".github/workflows/healthcheck-streaming.yml"
@@ -110,11 +116,15 @@ jobs:
       run: Start-Process ".\Minimal\Binaries\Win64\Minimal-Cmd.exe" -ArgumentList "-warp","-dx12","-windowed","-resx=1920","-resy=720","-PixelStreamingURL=ws://localhost:8888","-RenderOffScreen","-AllowSoftwareRendering","-PixelStreamingEncoderCodec=vp8", "-Log=Minimal.log"
 
     - name: Wait for signalling to come up
-      run: curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
+      run: curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
 
     - name: Wait for streamer to come up
-      run: curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/streamers/DefaultStreamer
+      run: curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/streamers/DefaultStreamer
+
+    - name: Output signalling logs
+      working-directory: SignallingWebServer
+      run: ls .\logs\ && cat .\logs\*.log
 
     - name: Output streamer logs
       working-directory: Streamer


### PR DESCRIPTION
There were several changes into how we handle the actions in the preparation for UE5.6. Those needed to be moved back to 5.5 to make sure the actions stay robust and are doing the right thing.
