### PR TITLE
chore: Updating CJS configurations of published libraries.

### DIFF
--- a/.changeset/poor-cows-follow.md
+++ b/.changeset/poor-cows-follow.md
@@ -1,0 +1,9 @@
+---
+'@epicgames-ps/reference-pixelstreamingfrontend-ue5.5': minor
+'@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.5': minor
+'@epicgames-ps/lib-pixelstreamingfrontend-ue5.5': minor
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.5': minor
+'@epicgames-ps/lib-pixelstreamingcommon-ue5.5': minor
+---
+
+Changed module type from cjs to node16 for the CommonJS version of the package. This fixes issues with some dependencies and also brings things to be slightly more modern.

--- a/Common/tsconfig.cjs.json
+++ b/Common/tsconfig.cjs.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs",
-        "moduleResolution": "node10"
+        "module": "node16",
+        "moduleResolution": "node16"
     }
 }

--- a/Frontend/implementations/typescript/tsconfig.cjs.json
+++ b/Frontend/implementations/typescript/tsconfig.cjs.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs",
-        "moduleResolution": "node10"
+        "module": "node16",
+        "moduleResolution": "node16"
     }
 }

--- a/Frontend/library/tsconfig.cjs.json
+++ b/Frontend/library/tsconfig.cjs.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs",
-        "moduleResolution": "node10"
+        "module": "node16",
+        "moduleResolution": "node16"
     }
 }

--- a/Frontend/ui-library/tsconfig.cjs.json
+++ b/Frontend/ui-library/tsconfig.cjs.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs",
-        "moduleResolution": "node10"
+        "module": "node16",
+        "moduleResolution": "node16"
     }
 }

--- a/Signalling/tsconfig.cjs.json
+++ b/Signalling/tsconfig.cjs.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/cjs",
-        "module": "commonjs",
-        "moduleResolution": "node10"
+        "module": "node16",
+        "moduleResolution": "node16"
     }
 }


### PR DESCRIPTION
We were using a pretty old moduleresolution type 'node10' to build the commonjs versions of our libraries. This was causing issues when using some dependencies.
Updating it to 'node16' then complains that the module also needs to be 'node16'. I Previously thought that the module type needed to remain 'commonjs' to output cjs libraries but this is incorrect. The module type of 'node16' also allows commonjs output and is more modern so will prevent issues with other modules.

cherry-picked from UE5.6