### PR TITLE
[UE5.6] chore(actions): Explicitly adding permissions to all workflows. (#642)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport PR

--- a/.github/workflows/changesets-publish-npm-packages.yml
+++ b/.github/workflows/changesets-publish-npm-packages.yml
@@ -14,6 +14,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   # gets all publishable npm packages.
   fetch-package-info:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.query-packages.outputs.matrix }}

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -11,6 +11,9 @@ on:
       - "SignallingWebServer/**"
       - "Extras/**"
 
+permissions:
+  contents: write
+
 jobs:
   streaming-test-linux:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-image-sfu.yml
+++ b/.github/workflows/healthcheck-image-sfu.yml
@@ -7,6 +7,9 @@ on:
       - ".github/workflow/healthcheck-image-sfu.yml"
       - "SFU/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-docker-image:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-image-wilbur.yml
+++ b/.github/workflows/healthcheck-image-wilbur.yml
@@ -7,6 +7,9 @@ on:
       - ".github/workflows/healthcheck-image-wilbur.yml"
       - "SignallingWebServer/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-docker-image:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -12,6 +12,9 @@ on:
       - "Frontend/ui-library/**"
       - "Frontend/implementations/typescript/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-using-local-deps:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-libs-with-public-deps.yml
+++ b/.github/workflows/healthcheck-libs-with-public-deps.yml
@@ -6,6 +6,9 @@ on:
       commitsha:
         description: "Commit SHA for the release (if blank use latest on this branch)"
 
+permissions:
+  contents: read
+
 env:
   commitsha: "${{ github.event.inputs.commitsha || github.sha }}"
 

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -5,6 +5,10 @@ on:
   # schedule:
   #   - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   linkChecker:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -7,6 +7,9 @@ on:
       - ".github/workflows/healthcheck-platform-scripts.yml"
       - "SignallingWebServer/**"
 
+permissions:
+  contents: read
+
 jobs:
   run-script-linux:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-signalling-protocol.yml
+++ b/.github/workflows/healthcheck-signalling-protocol.yml
@@ -10,6 +10,9 @@ on:
       - "SignallingWebServer/**"
       - "Extras/SS_Test/**"
 
+permissions:
+  contents: read
+
 jobs:
   signalling-protocol-test:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -1,8 +1,5 @@
 name: Check health of streaming
 
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
   push:
@@ -16,6 +13,9 @@ on:
       - "Signalling/**"
       - "SignallingWebServer/**"
       - "Extras/**"
+
+permissions:
+  contents: read
 
 jobs:
   # Uncomment when we can Linux test to capture a non-black screenshot using software renderer.

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -8,6 +8,9 @@ on:
     paths: 
       - 'SFU/package.json'
 
+permissions:
+  contents: write
+
 jobs:
   signalling-server-image:
     if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,11 +6,14 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/stale@v8
       with:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.6`:
 - [chore(actions): Explicitly adding permissions to all workflows. (#642)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/642)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)