### PR TITLE
Backport action needs contents write.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,7 @@ on:
     types: ["labeled", "closed"]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Accidentally set the contents permission to read so now the backports cannot be created.
