### PR TITLE
Fix regression in start.bat/start.sh not using changed source when building locally

### DIFF
--- a/Frontend/implementations/typescript/webpack.base.js
+++ b/Frontend/implementations/typescript/webpack.base.js
@@ -32,7 +32,7 @@ module.exports = {
             /node_modules/,
           ],
           options: {
-            configFile: "tsconfig.cjs.json"
+            configFile: "tsconfig.esm.json"
           }
         },
         {

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -224,11 +224,14 @@ function setup_frontend() {
 	if [ ! -d "${WEBPACK_OUTPUT_PATH}" ] || [ "$BUILD_FRONTEND" == "1" ] ; then
 		echo "Building Typescript Frontend."
 		# Using our bundled NodeJS, build the web frontend files
+        pushd "${SCRIPT_DIR}/../../../Common" > /dev/null
+		npm run build:esm
+		popd > /dev/null
 		pushd "${SCRIPT_DIR}/../../../Frontend/library" > /dev/null
-		npm run build:cjs
+		npm run build:esm
 		popd > /dev/null
 		pushd "${SCRIPT_DIR}/../../../Frontend/ui-library" > /dev/null
-		npm run build:cjs
+		npm run build:esm
 		popd > /dev/null
 		pushd "${SCRIPT_DIR}/../../../Frontend/implementations/typescript" > /dev/null
 		npm run build:dev

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -216,13 +216,17 @@ IF "%BUILD_FRONTEND%"=="1" (
     rem We could replace this all with a single npm script that does all this. we do have several build-all scripts already
     rem but this does give a good reference about the dependency chain for all of this.
     echo Building Typescript frontend...
+    pushd %CD%\Common
+    call %NPM% run build:esm
+    popd
     pushd %CD%\Frontend\library
-    call %NPM% run build:cjs
+    call %NPM% run build:esm
     popd
     pushd %CD%\Frontend\ui-library
-    call %NPM% run build:cjs
+    call %NPM% run build:esm
     popd
     pushd %CD%\Frontend\implementations\typescript
+    rem Note: build:dev implicitly uses esm deps due to node16/bundler module resolution
     call %NPM% run build:dev
     popd
     popd


### PR DESCRIPTION
## Relevant components:
- [x] Platform scripts

## Problem statement:
Platform scripts were configured to build frontend and common as CJS; however, the reference frontend will always use ESM deps because it uses webpack. This meant if changes were made to source code but esm build had not been invoked by some other script then start.bat would use out of date ESM files because only the CJS was getting built.

## Solution
start.bat/start.sh now build the esm versions of the frontend and common deps

## Documentation
No docs required, this is fixing a regression.

## Test Plan and Compatibility
- Tested locally on Windows
- Will also test that CI passes
