### PR TITLE
Fixing argument issues with Wilbur and platform scripts

### DIFF
--- a/.changeset/sweet-foxes-remain.md
+++ b/.changeset/sweet-foxes-remain.md
@@ -1,0 +1,13 @@
+---
+'@epicgames-ps/wilbur': minor
+---
+
+- Added separator between script parameters and signalling server parameters when using platform scripts
+  - From now on, anything after the `--` marker on the command line is passed directly to Wilbur.
+  - Parameters before this marker are intended for the scripts. These parameters are validated and unknown parameters will cause an error.
+- Added the new `--peer_options_file` parameter to the signalling server.
+  - JSON data is problematic to pass on the command line.
+  - This new parameter allows you to use a JSON file as your peer options for the server.
+  - Using `--peer_options` is now discouraged.
+- Fixed issue with passing peer_options while using platform scripts.
+

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--" "--rest_api","--player_port 999"
+          Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--", "--rest_api","--player_port 999"
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
+          ./platform_scripts/bash/start.sh -- --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-macos:
@@ -32,7 +32,7 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          ./platform_scripts/bash/start.sh --rest_api --player_port 999 &
+          ./platform_scripts/bash/start.sh -- --rest_api --player_port 999 &
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-windows:
@@ -44,5 +44,5 @@ jobs:
       - name: Launch and query signalling server using the REST API
         working-directory: SignallingWebServer
         run: |
-          Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--rest_api","--player_port 999"
+          Start-Process -NoNewWindow ".\platform_scripts\cmd\start.bat" -ArgumentList "--" "--rest_api","--player_port 999"
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status

--- a/Extras/FrontendTests/docker-compose.yml
+++ b/Extras/FrontendTests/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../../
       dockerfile: ./SignallingWebServer/Dockerfile
     image: signalling
-    command: --rest_api
+    command: -- --rest_api
     networks:
       - testing
     healthcheck:

--- a/Extras/MinimalStreamTester/docker-compose.yml
+++ b/Extras/MinimalStreamTester/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../../
       dockerfile: ./SignallingWebServer/Dockerfile
     image: signalling
-    command: --rest_api
+    command: -- --rest_api
     networks:
       - testing
     healthcheck:

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -6,7 +6,7 @@ NODE_VERSION=$(<"${SCRIPT_DIR}/../../../NODE_VERSION")
 function print_usage() {
     echo "
     Script usage:
-        ${0} [--help] [--publicip <IP Address>] [--turn <turn server>] [--stun <stun server>] [server options...]
+        ${0} [--help] [--publicip <IP Address>] [--turn <turn server>] [--stun <stun server>] -- [server options...]
     Where:
         --help              Print this message and stop this script.
         --debug             Run all scripts with --inspect
@@ -66,11 +66,16 @@ function parse_args() {
         --build-libraries ) BUILD_LIBRARIES=1; shift;;
         --deps ) INSTALL_DEPS=1; shift;;
         --help ) print_usage;;
-        * ) SERVER_ARGS+=" $1"; shift;;
+        -- ) shift; break;;
+        * )
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
         esac
     done
-    if [[ ! -z "${SERVER_ARGS}" ]]; then
-        echo "Parameters being passed to server: ${SERVER_ARGS}"
+    SERVER_ARGS+=$@
+    if [[ ! -z "$@" ]]; then
+        echo "Parameters being passed to server: $@"
     fi
 }
 

--- a/SignallingWebServer/platform_scripts/bash/start.sh
+++ b/SignallingWebServer/platform_scripts/bash/start.sh
@@ -9,13 +9,24 @@ setup $@
 set_public_ip
 setup_turn_stun "bg"
 
+TEST_ARGS=($SERVER_ARGS)
+SKIP_PEER_ARGS=false
+for arg in "${TEST_ARGS[@]}"; do
+    if [[ "$arg" == --peer_options* ]]; then
+        SKIP_PEER_ARGS=true
+        break;
+    fi
+done
+
 SERVER_ARGS+=" --serve --https_redirect --console_messages verbose --log_config --public_ip=${PUBLIC_IP}"
-if [[ ! -z "$STUN_SERVER" && ! -z "$TURN_SERVER" ]]; then
-    PEER_OPTIONS="{\"iceServers\":[{\"urls\":[\"stun:${STUN_SERVER}\",\"turn:${TURN_SERVER}\"],\"username\":\"${TURN_USER}\",\"credential\":\"${TURN_PASS}\"}]}"
-elif [[ ! -z "$STUN_SERVER" ]]; then
-    PEER_OPTIONS="{\"iceServers\":[{\"urls\":[\"stun:${STUN_SERVER}\"]}]}"
-elif [[ ! -z "$TURN_SERVER" ]]; then
-    PEER_OPTIONS="{\"iceServers\":[{\"urls\":[\"turn:${TURN_SERVER}\"],\"username\":\"${TURN_USER}\",\"credentials\":\"${TURN_PASS}\"}]}"
+if [[ $SKIP_PEER_ARGS == false ]]; then
+    if [[ ! -z "$STUN_SERVER" && ! -z "$TURN_SERVER" ]]; then
+        PEER_OPTIONS="{\"iceServers\":[{\"urls\":[\"stun:${STUN_SERVER}\",\"turn:${TURN_SERVER}\"],\"username\":\"${TURN_USER}\",\"credential\":\"${TURN_PASS}\"}]}"
+    elif [[ ! -z "$STUN_SERVER" ]]; then
+        PEER_OPTIONS="{\"iceServers\":[{\"urls\":[\"stun:${STUN_SERVER}\"]}]}"
+    elif [[ ! -z "$TURN_SERVER" ]]; then
+        PEER_OPTIONS="{\"iceServers\":[{\"urls\":[\"turn:${TURN_SERVER}\"],\"username\":\"${TURN_USER}\",\"credentials\":\"${TURN_PASS}\"}]}"
+    fi
 fi
 if [[ ! -z "$PEER_OPTIONS" ]]; then
     SERVER_ARGS+=" --peer_options='${PEER_OPTIONS}'"

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -9,13 +9,12 @@ set SCRIPT_DIR=%~dp0
 set /p NODE_VERSION=<"%SCRIPT_DIR%/../../../NODE_VERSION"
 set NPM="%SCRIPT_DIR%/node/npm"
 set TAR="%SystemRoot%\System32\tar.exe"
-set CONTINUE=1
 GOTO :eof
 
 :Usage
 echo.
 echo    Usage:
-echo        %0 [--help] [--publicip ^<IP Address^>] [--turn ^<turn server^>] [--stun ^<stun server^>] [server options...]
+echo        %0 [--help] [--publicip ^<IP Address^>] [--turn ^<turn server^>] [--stun ^<stun server^>] -- [server options...]
 echo    Where:
 echo        --help              Print this message and stop this script.
 echo        --publicip          Define public ip address (using default port) for turn server, syntax: --publicip ; it is used for 
@@ -39,8 +38,7 @@ IF exist "%SCRIPT_DIR%..\..\dist" (
     call %NPM% run start --- --help
     popd
 )
-set CONTINUE=0
-exit /b
+exit /b 1
 
 :ParseArgs
 set BUILD_LIBRARIES=0
@@ -54,73 +52,84 @@ set TURN_USER=
 set TURN_PASS=
 set STUN_SERVER=
 set PUBLIC_IP=
+echo ARGS %*
 :arg_loop
-IF NOT "%1"=="" (
-    set HANDLED=0
-    IF "%1"=="--help" (
-        CALL :Usage
-        exit /b
-    )
-    IF "%1"=="--publicip" (
-        set HANDLED=1
-        set PUBLIC_IP=%2
-        SHIFT
-    )
-    IF "%1"=="--turn" (
-        set HANDLED=1
-        set TURN_SERVER=%2
-        SHIFT
-    )
-    IF "%1"=="--turn-user" (
-        set HANDLED=1
-        set TURN_USER=1
-    )
-    IF "%1"=="--turn-pass" (
-        set HANDLED=1
-        set TURN_PASS=1
-    )
-    if "%1"=="--start-turn" (
-        set HANDLED=1
-        set START_TURN=1
-    )
-    IF "%1"=="--stun" (
-        set HANDLED=1
-        set STUN_SERVER=%2
-        SHIFT
-    )
-    IF "%1"=="--frontend-dir" (
-        set HANDLED=1
-        set FRONTEND_DIR=%~2
-        SHIFT
-    )
-    IF "%1"=="--build" (
-        set HANDLED=1
-        set BUILD_FRONTEND=1
-    )
-    IF "%1"=="--rebuild" (
-        set HANDLED=1
-        set BUILD_LIBRARIES=1
-        set BUILD_FRONTEND=1
-        set BUILD_WILBUR=1
-    )
-    IF "%1"=="--build-libraries" (
-        set HANDLED=1
-        set BUILD_LIBRARIES=1
-    )
-    IF "%1"=="--build-wilbur" (
-        set HANDLED=1
-        set BUILD_WILBUR=1
-    )
-    IF "%1"=="--deps" (
-        set HANDLED=1
-        set INSTALL_DEPS=1
-    )
-    IF NOT "!HANDLED!"=="1" (
-        set SERVER_ARGS=%SERVER_ARGS% %1
-    )
-    SHIFT
-    GOTO :arg_loop
+IF "%1"=="" GOTO LoopExit
+IF "%1"=="--" GOTO PostArgs
+set HANDLED=0
+IF "%1"=="--help" (
+    CALL :Usage
+    exit /b
 )
+IF "%1"=="--publicip" (
+    set HANDLED=1
+    set PUBLIC_IP=%2
+    SHIFT
+)
+IF "%1"=="--turn" (
+    set HANDLED=1
+    set TURN_SERVER=%2
+    SHIFT
+)
+IF "%1"=="--turn-user" (
+    set HANDLED=1
+    set TURN_USER=1
+)
+IF "%1"=="--turn-pass" (
+    set HANDLED=1
+    set TURN_PASS=1
+)
+if "%1"=="--start-turn" (
+    set HANDLED=1
+    set START_TURN=1
+)
+IF "%1"=="--stun" (
+    set HANDLED=1
+    set STUN_SERVER=%2
+    SHIFT
+)
+IF "%1"=="--frontend-dir" (
+    set HANDLED=1
+    set FRONTEND_DIR=%~2
+    SHIFT
+)
+IF "%1"=="--build" (
+    set HANDLED=1
+    set BUILD_FRONTEND=1
+)
+IF "%1"=="--rebuild" (
+    set HANDLED=1
+    set BUILD_LIBRARIES=1
+    set BUILD_FRONTEND=1
+    set BUILD_WILBUR=1
+)
+IF "%1"=="--build-libraries" (
+    set HANDLED=1
+    set BUILD_LIBRARIES=1
+)
+IF "%1"=="--build-wilbur" (
+    set HANDLED=1
+    set BUILD_WILBUR=1
+)
+IF "%1"=="--deps" (
+    set HANDLED=1
+    set INSTALL_DEPS=1
+)
+IF NOT "!HANDLED!"=="1" (
+    echo Unknown arg %1
+    exit /b 1
+)
+SHIFT
+GOTO :arg_loop
+
+:PostArgs
+SHIFT
+IF "%1"=="" GOTO LoopExit
+set SERVER_ARGS=%SERVER_ARGS% %1
+GOTO PostArgs
+
+:LoopExit
+echo SERVER_ARGS = %SERVER_ARGS%
 exit /b
 
 :SetupNode

--- a/SignallingWebServer/platform_scripts/cmd/start.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start.bat
@@ -7,35 +7,51 @@ title Wilbur
 call :Init
 call :ParseArgs %*
 
-IF "%CONTINUE%"=="1" (
-	call :Setup
-	call :SetPublicIP
-	call :SetupTurnStun bg
+IF errorlevel 1 (
+	exit /b 1
+)
 
-	set PEER_OPTIONS=
-	set SERVER_ARGS=!SERVER_ARGS! --serve --console_messages verbose --https_redirect --log_config --public_ip=!PUBLIC_IP!
-	IF NOT "!STUN_SERVER!"=="" (
-		IF NOT "!TURN_SERVER!"=="" (
-			set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"stun:!STUN_SERVER!\",\"turn:!TURN_SERVER!\"],\"username\":\"!TURN_USER!\",\"credential\":\"!TURN_PASS!\"}]}
-		) ELSE (
-			set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"stun:!STUN_SERVER!\"]}]}
-		)
-	) ELSE IF NOT "!TURN_SERVER!"=="" (
-		set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"turn:!TURN_SERVER!\"],\"username\":\"!TURN_USER!\",\"credentials\":\"!TURN_PASS!\"}]}
+call :Setup
+call :SetPublicIP
+call :SetupTurnStun bg
+
+set PEER_OPTIONS=
+set SERVER_ARGS=!SERVER_ARGS! --serve --console_messages verbose --https_redirect --log_config --public_ip=!PUBLIC_IP!
+IF NOT "!STUN_SERVER!"=="" (
+	IF NOT "!TURN_SERVER!"=="" (
+		set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"stun:!STUN_SERVER!\",\"turn:!TURN_SERVER!\"],\"username\":\"!TURN_USER!\",\"credential\":\"!TURN_PASS!\"}]}
+	) ELSE (
+		set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"stun:!STUN_SERVER!\"]}]}
 	)
+) ELSE IF NOT "!TURN_SERVER!"=="" (
+	set PEER_OPTIONS={\"iceServers\":[{\"urls\":[\"turn:!TURN_SERVER!\"],\"username\":\"!TURN_USER!\",\"credentials\":\"!TURN_PASS!\"}]}
+)
 
+echo !SERVER_ARGS! | findstr /C:"--peer_options" >nul
+if !errorlevel! == 0 (
+	set PEER_OPTIONS_SUPPLIED=true
+)
+IF NOT "!PEER_OPTIONS_SUPPLIED!"=="true" (
 	IF NOT "!PEER_OPTIONS!"=="" (
 		set SERVER_ARGS=!SERVER_ARGS! --peer_options="!PEER_OPTIONS!"
 	)
+)
+
+
+echo !SERVER_ARGS! | findstr /C:"--http_root" >nul
+if !errorlevel! == 0 (
+	set HTTP_ROOT_SUPPLIED=true
+)
+IF NOT "!HTTP_ROOT_SUPPLIED!"=="true" (
 	IF NOT "!FRONTEND_DIR!"=="" (
 		set SERVER_ARGS=!SERVER_ARGS! --http_root="!FRONTEND_DIR!"
 	)
-	
-    call :BuildWilbur
-    call :PrintConfig
-	call :StartWilbur
-	pause
 )
+
+call :BuildWilbur
+call :PrintConfig
+call :StartWilbur
+pause
 
 goto :eof
 

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -147,6 +147,12 @@ program
             .argParser(JSON.parse)
             .default(config_file.peer_options || '')
     )
+    .addOption(
+        new Option(
+            '--peer_options_file <filename>',
+            'Additional JSON data to send in peerConnectionOptions of the config message. This allows you to provide JSON data without having to deal with it on the command line.'
+        ).default(config_file.peer_options_file || '')
+    )
     .option(
         '--reverse-proxy',
         'Enables reverse proxy mode. This will trust the X-Forwarded-For header.',
@@ -199,6 +205,20 @@ InitLogging({
     logLevelConsole: options.log_level_console,
     logLevelFile: options.log_level_file
 });
+
+// read the peer_options_file
+if (options.peer_options_file) {
+    if (!fs.existsSync(options.peer_options_file)) {
+        Logger.error(`peer_options_file "${options.peer_options_file}" does not exist.`);
+        throw Error('Failed.');
+    }
+
+    options.peer_options = JSON.parse(fs.readFileSync(options.peer_options_file, 'utf-8'));
+} else if (options.peer_options) {
+    Logger.warn(
+        `The --peer_options cli flag has many issues with passing JSON data on the command line. It is recommended that you use --peer_options_file instead.`
+    );
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 Logger.info(`${pjson.name} v${pjson.version} starting...`);

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -205,7 +205,7 @@ Logger.info(`${pjson.name} v${pjson.version} starting...`);
 if (options.log_config) {
     Logger.info('Config:');
     for (const key in options) {
-        Logger.info(`"${key}": "${options[key]}"`);
+        Logger.info(`"${key}": ${JSON.stringify(options[key])}`);
     }
 }
 

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -210,7 +210,7 @@ InitLogging({
 if (options.peer_options_file) {
     if (!fs.existsSync(options.peer_options_file)) {
         Logger.error(`peer_options_file "${options.peer_options_file}" does not exist.`);
-        throw Error('Failed.');
+        throw Error(`Failed to find a peer options config file a file called ${options.peer_options_file}.`);
     }
 
     options.peer_options = JSON.parse(fs.readFileSync(options.peer_options_file, 'utf-8'));


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
The current platform scripts don't allow you to pass --peer_options (and possibly some other parameters) to Wilbur because the argument is constructed in the platform scripts themselves and replaces any user passed peer_options.

## Solution
The platform scripts now check if any parameter it would normally pass to Wilbur already were passed by the user. If so it skips adding that parameter to the call to Wilbur.

Another change that comes with this is the implementation of an explicit delimeter between script arguments and Wilbur arguments that will be passed directly. Now anything before the `--` marker is treated as a script parameter, and if an unknown parameter is found an error is produced (previously unknown parameters would be passed to Wilbur). And anything after the marker is passed directly to Wilbur. This means after this update, users will need to properly separate script parameters and Wilbur parameters with `--`.

One final change with this PR is that there is a new `--peer_options_file` parameter for Wilbur. JSON is notoriously bad to pass as a command line argument value due to formatting, escaping, spaces etc. It does not parse well on the command line. To aleviate this, I have added the new `--peer_options_file` parameter that allows users to provide a JSON file for the peer options. This file is read, parsed and passed in as the peer options for the signalling server..

Fixes #650

## Documentation
