### PR TITLE
Fix: SFU crashing due to _sctpStreamIds being null. Code using this m…

### DIFF
--- a/.changeset/slow-dragons-promise.md
+++ b/.changeset/slow-dragons-promise.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/pixelstreaming-sfu": patch
+---
+
+Fix: SFU crashing due to _sctpStreamIds being null. Code using this member has been removed as the `getNextSctpStreamId()` function provided by MediaSoup provides the same functionality.


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [X] SFU

## Problem statement:
The SFU is currently crashing due to the transport `_sctpStreamIds` member being null. MediaSoup no longer exposes this member. However, our code that required it is also no longer needed as the `getNextSctpStreamId()` method provides the same functionality.

## Solution
Remove usages of `_sctpStreamIds`

## Test Plan and Compatibility
Tested SFU and multi-peer with both `Pixel Streaming` and `Pixel Streaming 2`