### PR TITLE
Fix: Firefox connectivity issues caused by PR694

### DIFF
--- a/.changeset/light-games-wonder.md
+++ b/.changeset/light-games-wonder.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/lib-pixelstreamingfrontend-ue5.7': patch
+---
+
+Some versions of Firefox were unable to connect due the changes in PR#694 to overcome this issue and preserve the connectivity fixes from PR#694 we now assume the sdpMLineIndex is always 0 for bundle master media line. This change was tested on many browsers and restores connectivity with FireFox.

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1485,13 +1485,13 @@ export class WebRtcPlayerController {
     handleIceCandidate(iceCandidateInit: RTCIceCandidateInit) {
         Logger.Info(`Remote ICE candidate information received: ${JSON.stringify(iceCandidateInit)}`);
 
-        // We are using "bundle" policy for media lines so we remove the sdpMid and sdpMLineIndex attributes
-        // from ICE candidates as these are legacy attributes for when bundle is not used.
+        // We are using "bundle" policy for media lines so we manually set the sdpMLineIndex attribute to 0 (our assumed bundle master media line)
         // If we don't do this the browser may be unable to form a media connection
-        // because some browsers are brittle if the bundle master (e.g. commonly mid=0) doesn't get a candidate first.
+        // because some browsers are brittle if the bundle master doesn't get a candidate first.
+        // Note: This assumes we are using bundle and that the bundle master is the first media line (0).
         const remoteIceCandidate = new RTCIceCandidate({
             candidate: iceCandidateInit.candidate,
-            sdpMid: ''
+            sdpMLineIndex: 0
         });
 
         this.peerConnectionController.handleOnIce(remoteIceCandidate);


### PR DESCRIPTION
## Relevant components:
- [x] Frontend library

## Problem statement:
As a result of https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/694 sometimes Firefox was unable to connect. It would error with `uncaught (in promise) DOMException: Cannot set ICE candidate for level=<Nothing> mid=: No such transceiver.`

## Solution
This PR patches the previous fix by hard coding the `sdpMLineIndex` to `0` which resolves the issue on Firefox and maintains working connectivity on the other browsers. This change means we assume:

1. Bundle is being used for WebRTC media
2. The master media line of the bundle is in index 0.

Both of these assumptions hold for all versions of Pixel Streaming 1 and 2 to date.

## Documentation
N/A - This is very implementation specific, but this PR should serve as a good record.

## Test Plan and Compatibility
Tested:

Chrome + AWS 
Chrome + TailScale
Firefox + AWS
FireFox + TailScale
Safari + AWS
Safari + TailScale

All these combinations were able to stream correctly.
