### PR TITLE
Update signalling_messages.proto

### DIFF
--- a/Common/protobuf/signalling_messages.proto
+++ b/Common/protobuf/signalling_messages.proto
@@ -246,7 +246,7 @@ message ping {
   // Should always be 'ping'
   string type = 1;
   // The current time
-  int32 time = 2;
+  int64 time = 2;
 }
 
 /**
@@ -257,7 +257,7 @@ message pong {
   // Should always be 'pong'
   string type = 1;
   // The echoed time from the ping message
-  int32 time = 2;
+  int64 time = 2;
 }
 
 /**

--- a/Common/protobuf/signalling_messages.proto
+++ b/Common/protobuf/signalling_messages.proto
@@ -131,12 +131,12 @@ message unsubscribe {
 /**
  * Sent in response to a subscribe message when something goes wrong.
  */
- message subscribeFailed {
-     // Should always be 'subscribeFailed'
-     string type = 1;
-     // A description of what went wrong.
-     string message = 2;
- }
+message subscribeFailed {
+  // Should always be 'subscribeFailed'
+  string type = 1;
+  // A description of what went wrong.
+  string message = 2;
+}
 
 /**
  * A message sent to a streamer to notify it that a player has just

--- a/Common/protobuf/signalling_messages.proto
+++ b/Common/protobuf/signalling_messages.proto
@@ -293,6 +293,9 @@ message layerPreference {
 message dataChannelRequest {
   // Should always be 'dataChannelRequest'
   string type = 1;
+
+  // The player ID this message refers to.
+  optional string playerId = 2;
 }
 
 /**
@@ -317,6 +320,9 @@ message peerDataChannels {
 message peerDataChannelsReady {
   // Should always be 'peerDataChannelsReady'
   string type = 1;
+
+  // The player ID this message refers to.
+  optional string playerId = 2;
 }
 
 /**
@@ -332,6 +338,8 @@ message streamerDataChannels {
   int32 sendStreamId = 3;
   // The channel ID to use for receiving data.
   int32 recvStreamId = 4;
+  // The player ID this message refers to.
+  string playerId = 5;
 }
 
 /**


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
1. The `time` field of `ping` and `pong` messages needs to be of type `int64` to allow for milliseconds (which is how it's done in the implementation).
2. There are a few `playerId` fields missing from the proto messages that are actually used/sent in the implementation.

## Solution
How does this PR solve the problem?
1. Changed the type of `time` to `int64`.
2. Added the missing fields.

## Documentation
If you added a new feature or changed an existing feature please add some documentation here.

Or better yet, link to the relevant `/Docs` update in your PR.

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compataibility with the existing functionality? 

Or better yet, link to the unit tests that accompany this PR.
