### PR TITLE
fixing public ip stomping in windows batch script.

### DIFF
--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -272,8 +272,10 @@ call :SetupCoturn
 exit /b
 
 :SetPublicIP
-FOR /f %%A IN ('curl --silent http://api.ipify.org') DO set PUBLIC_IP=%%A
-Echo External IP is : %PUBLIC_IP%
+IF "%PUBLIC_IP%"=="" (
+    FOR /f %%A IN ('curl --silent http://api.ipify.org') DO set PUBLIC_IP=%%A
+    Echo External IP is : %PUBLIC_IP%
+)
 exit /b
 
 :SetupTurnStun


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
When supplying --publicip on the windows batch scripts it was getting overridden.

## Solution
The SetPublicIP step now checks that no ip has been previously specified.
