### PR TITLE
Add guard against closed peerConnection

### DIFF
--- a/.changeset/eighty-snakes-sneeze.md
+++ b/.changeset/eighty-snakes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.7": patch
+---
+
+Add guard against closed `peerConnection` in `generateStats`

--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -173,8 +173,12 @@ export class PeerConnectionController {
     generateStats() {
         this.peerConnection?.getStats().then((statsData: RTCStatsReport) => {
             this.aggregatedStats.processStats(statsData);
-
             this.onVideoStats(this.aggregatedStats);
+
+            // Connection might have been closed in the meantime
+            if (!this.peerConnection) {
+                return;
+            }
 
             // Calculate latency using stats and video receivers and then call the handling function
             const latencyInfo: LatencyInfo = this.latencyCalculator.calculate(


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Similar to #719: Fix for throwing error when `peerConnection` is not defined. We see some events in Sentry where `peerConnection` has been available at the start of the function, but not anymore in the `then` callback; the connection must have been closed in the meantime.

## Solution
Currently when `peerConnection` is not defined, the rest of the function is not executed because an error is thrown (`null is not an object (evaluating 'this.peerConnection.getReceivers')`). Now the error is silenced and the return statement still prevents further execution.

## Documentation
N/A

## Test Plan and Compatibility
There are no code behavior changes, apart from no error being thrown anymore. The error previously was unhandled because `generateStats` was called in a window interval (via `WebRtcPlayerController.getStats`).