### PR TITLE
ci: allow backport workflow to use a PAT to trigger downstream CI

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,13 @@ jobs:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.5.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT when configured. PRs opened with the default
+          # GITHUB_TOKEN don't trigger downstream `pull_request` workflows
+          # (anti-recursion limit), which means CI does not run on backport
+          # PRs. Configure a repo or org secret named BACKPORT_PAT
+          # (PAT with `repo` scope) to fix that. Falls back to GITHUB_TOKEN
+          # if the secret is not set, preserving the prior behavior.
+          github_token: ${{ secrets.BACKPORT_PAT || secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: auto-backport-to-
           add_original_reviewers: true
 


### PR DESCRIPTION
## Summary
- Read `github_token` from `secrets.BACKPORT_PAT || secrets.GITHUB_TOKEN` in `.github/workflows/backport.yml`.
- Behaviour is unchanged when `BACKPORT_PAT` is not set.
- Once a repo or org secret named `BACKPORT_PAT` is configured (a PAT with `repo` scope), backport PRs will trigger downstream `pull_request` workflows like the rest of CI.

GitHub deliberately doesn't fire `pull_request` events for PRs opened with the default `GITHUB_TOKEN` (anti-recursion safeguard), which is why backport PRs land without CI running on them.

## Test plan
- [x] Repo admin adds a `BACKPORT_PAT` secret (PAT with `repo` scope).
- [ ] Trigger a backport on a test PR; verify the resulting backport PR runs the usual CI workflows.
- [x] No-secret fallback: workflow still resolves to `GITHUB_TOKEN`, so behaviour is unchanged for forks / contributors who haven't configured the secret.

Closes #655.