### PR TITLE
[UE5.5] fix(mediasoup-sdp-bridge): support mediasoup-client 3.10.x (#685) (#852)

### DIFF
--- a/.changeset/mediasoup-sdp-bridge-3.10.md
+++ b/.changeset/mediasoup-sdp-bridge-3.10.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/mediasoup-sdp-bridge": patch
+---
+
+Make `mediasoup-sdp-bridge` importable against `mediasoup-client` 3.10.x (#685). Internal subpaths under `mediasoup-client/lib/...` were hidden by the `exports` field added in 3.8.0, breaking `import * as MsSdpUtils from "mediasoup-client/lib/handlers/sdp/commonUtils"` etc. with `ERR_PACKAGE_PATH_NOT_EXPORTED`. The imports now use the public paths exposed since 3.10.0 (`mediasoup-client/handlers/sdp/commonUtils`, `mediasoup-client/handlers/sdp/RemoteSdp`, `mediasoup-client/handlers/sdp/unifiedPlanUtils`, `mediasoup-client/ortc`) and the publicly re-exported `IceCandidate` from `mediasoup-client/types`. The peerDependency is tightened to `>=3.10.0 <3.11.0` to flag the supported range — 3.11 added a mandatory third arg to `getExtendedRtpCapabilities` and 3.16 renamed `validateRtpCapabilities`, both of which need follow-up work before they can be supported. The unsupported `extmapAllowMixed` option on `RemoteSdp.send` was removed.

--- a/Extras/mediasoup-sdp-bridge/package.json
+++ b/Extras/mediasoup-sdp-bridge/package.json
@@ -64,7 +64,7 @@
     "jest": "^29.7.0",
     "jest-tobetype": "^1.2.3",
     "mediasoup": "3.15.5",
-    "mediasoup-client": "3.9.1",
+    "mediasoup-client": "~3.10.0",
     "open-cli": "^6.0.1",
     "prettier": "~2.5.0",
     "tsc-watch": "^4.2.8",
@@ -72,6 +72,6 @@
   },
   "peerDependencies": {
     "mediasoup": "^3.0.0",
-    "mediasoup-client": "^3.0.0"
+    "mediasoup-client": ">=3.10.0 <3.11.0"
   }
 }

--- a/Extras/mediasoup-sdp-bridge/src/SdpUtils.ts
+++ b/Extras/mediasoup-sdp-bridge/src/SdpUtils.ts
@@ -1,10 +1,10 @@
 // TODO, FIXME: Here we're assuming that Unified Plan is the correct way to
 // handle the SDP messages. For a more robust handling, this should probably
 // depend on the actual type of SDP: plain, PlanB, or UnifiedPlan.
-import * as MsSdpUnifiedPlanUtils from "mediasoup-client/lib/handlers/sdp/unifiedPlanUtils";
+import * as MsSdpUnifiedPlanUtils from "mediasoup-client/handlers/sdp/unifiedPlanUtils";
 
-import * as MsSdpUtils from "mediasoup-client/lib/handlers/sdp/commonUtils";
-import * as MsOrtc from "mediasoup-client/lib/ortc";
+import * as MsSdpUtils from "mediasoup-client/handlers/sdp/commonUtils";
+import * as MsOrtc from "mediasoup-client/ortc";
 import {
   MediaKind,
   RtpCapabilities,

--- a/Extras/mediasoup-sdp-bridge/src/index.ts
+++ b/Extras/mediasoup-sdp-bridge/src/index.ts
@@ -1,6 +1,6 @@
-import * as MsSdpUtils from "mediasoup-client/lib/handlers/sdp/commonUtils";
-import { RemoteSdp } from "mediasoup-client/lib/handlers/sdp/RemoteSdp";
-import { IceCandidate as ClientIceCandidate } from "mediasoup-client/lib/Transport";
+import * as MsSdpUtils from "mediasoup-client/handlers/sdp/commonUtils";
+import { RemoteSdp } from "mediasoup-client/handlers/sdp/RemoteSdp";
+import { IceCandidate as ClientIceCandidate } from "mediasoup-client/types";
 
 import {
   Consumer,
@@ -208,7 +208,6 @@ export class SdpEndpoint {
         offerRtpParameters: this.producerOfferParams[i],
         answerRtpParameters: this.producers[i].rtpParameters,
         codecOptions: undefined,
-        extmapAllowMixed: false,
       });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,7 @@
                 "jest": "^29.7.0",
                 "jest-tobetype": "^1.2.3",
                 "mediasoup": "3.15.5",
-                "mediasoup-client": "3.9.1",
+                "mediasoup-client": "~3.10.0",
                 "open-cli": "^6.0.1",
                 "prettier": "~2.5.0",
                 "tsc-watch": "^4.2.8",
@@ -165,7 +165,7 @@
             },
             "peerDependencies": {
                 "mediasoup": "^3.0.0",
-                "mediasoup-client": "^3.0.0"
+                "mediasoup-client": ">=3.10.0 <3.11.0"
             }
         },
         "Extras/mediasoup-sdp-bridge/node_modules/prettier": {
@@ -2956,6 +2956,29 @@
             "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@lukeed/csprng": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+            "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@lukeed/uuid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+            "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@lukeed/csprng": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/@manypkg/find-root": {
             "version": "1.1.0",
@@ -7936,19 +7959,6 @@
                 "through": "~2.3.1"
             }
         },
-        "node_modules/event-target-shim": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-            "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            }
-        },
         "node_modules/eventemitter3": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -8120,14 +8130,16 @@
             "license": "MIT"
         },
         "node_modules/fake-mediastreamtrack": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-1.2.0.tgz",
-            "integrity": "sha512-AxHtlEmka1sqNoe3Ej1H1hJc9gjjO/6vCbCPm4D4QeEXvzhjYumA+iZ7wOi2WrmkAhGElHhBgWoNgJhFccectA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.2.1.tgz",
+            "integrity": "sha512-SITLc7UTDirSdgLGORrlmqjWLJtbtfIz/xO7DwVbJH3f0ds+NQok4ccl/WEzz49NSgiUlXf2wDW0+y5C+TO6EA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "event-target-shim": "^6.0.2",
-                "uuid": "^9.0.0"
+                "@lukeed/uuid": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -12063,23 +12075,22 @@
             }
         },
         "node_modules/mediasoup-client": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/mediasoup-client/-/mediasoup-client-3.9.1.tgz",
-            "integrity": "sha512-UZ4788O3AQGwUbSP6LEqG8s61URIN1YWjPC6t4GLGduNrBHrSnIekjeFDKPTWp9D8yTEYvPKRh2G+JQR5HXAQw==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/mediasoup-client/-/mediasoup-client-3.10.1.tgz",
+            "integrity": "sha512-elPurMLPOK31z8QQm3rxAnlN1a37o9Pr0bXE4KnVhdIwqQQb2/uIMMGCB2LelV3N6qtDgYjpTaOkBGGqc44LNg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@types/debug": "^4.1.12",
                 "@types/npm-events-package": "npm:@types/events@^3.0.3",
-                "awaitqueue": "^3.0.2",
+                "awaitqueue": "^3.2.0",
                 "debug": "^4.4.0",
-                "fake-mediastreamtrack": "^1.2.0",
-                "h264-profile-level-id": "^2.0.0",
+                "fake-mediastreamtrack": "^2.1.0",
+                "h264-profile-level-id": "^2.2.0",
                 "npm-events-package": "npm:events@^3.3.0",
-                "queue-microtask": "^1.2.3",
                 "sdp-transform": "^2.15.0",
                 "supports-color": "^10.0.0",
-                "ua-parser-js": "^2.0.2"
+                "ua-parser-js": "^2.0.3"
             },
             "engines": {
                 "node": ">=18"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [fix(mediasoup-sdp-bridge): support mediasoup-client 3.10.x (#685) (#852)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/852)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)