### PR TITLE
[UE5.7] fix(frontend): map macOS Command and Windows Meta keys (#276) (#847)

### DIFF
--- a/.changeset/macos-cmd-keys.md
+++ b/.changeset/macos-cmd-keys.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.7": patch
+---
+
+Map the macOS Command (and Windows Meta) keys to UE keycodes 91 (`LeftWindowKey`) and 92 (`RightWindowKey`). `KeyCodes.ts` now contains `MetaLeft`/`MetaRight` (and the legacy `OSLeft`/`OSRight`) entries, and `KeyboardController.getKeycode` normalizes the right-Cmd code so it no longer collides with `ContextMenu` (93) on browsers that report `keyCode === 93` for it, and so Firefox-on-Mac (which reports `keyCode === 224` for both Cmds) is also handled. Frontend portion of issue #276 — UE-side support for these key codes is tracked separately.

--- a/Frontend/library/src/Inputs/KeyCodes.ts
+++ b/Frontend/library/src/Inputs/KeyCodes.ts
@@ -110,5 +110,17 @@ export const CodeToKeyCode: ICodeToKeyCode = Object.freeze({
     PageDown: 34,
     Insert: 45,
     Delete: 46,
-    ContextMenu: 93
+    ContextMenu: 93,
+    // macOS Command and Windows Meta keys. The UE side maps key codes 91/92
+    // to LeftWindowKey/RightWindowKey (currently routed to EKeys::Invalid in
+    // stock UE — Epic-internal ticket UE-228795 enables them). Sending the
+    // codes from the frontend is harmless when UE has no binding and lets
+    // applications that patch UE handle Cmd/Win shortcuts.
+    MetaLeft: 91,
+    MetaRight: 92,
+    // Legacy KeyboardEvent.code values some browsers historically emitted
+    // for the same physical keys. Keep them mapped so we don't drop input
+    // on older browsers.
+    OSLeft: 91,
+    OSRight: 92
 });

--- a/Frontend/library/src/Inputs/KeyboardController.ts
+++ b/Frontend/library/src/Inputs/KeyboardController.ts
@@ -130,6 +130,16 @@ export class KeyboardController implements IInputController {
             return SpecialKeyCodes.rightControl;
         } else if (keyboardEvent.keyCode === SpecialKeyCodes.alt && keyboardEvent.code === 'AltRight') {
             return SpecialKeyCodes.rightAlt;
+        } else if (keyboardEvent.code === 'MetaLeft' || keyboardEvent.code === 'OSLeft') {
+            // Browsers disagree on the legacy keyCode for the left Cmd/Win
+            // key (Chrome/Safari report 91, Firefox on Mac reports 224).
+            // Normalize using `code`. UE LeftWindowKey is 91.
+            return CodeToKeyCode['MetaLeft'];
+        } else if (keyboardEvent.code === 'MetaRight' || keyboardEvent.code === 'OSRight') {
+            // Right Cmd/Win has the same browser disagreement, and on
+            // Chrome/Safari it shares keyCode 93 with the ContextMenu key.
+            // Normalize to 92 (UE RightWindowKey).
+            return CodeToKeyCode['MetaRight'];
         } else {
             return keyboardEvent.keyCode;
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [fix(frontend): map macOS Command and Windows Meta keys (#276) (#847)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/847)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)