### PR TITLE
[UE5.7] feat(frontend): add AutoEnterVR config flag (#461) (#850)

### DIFF
--- a/.changeset/auto-enter-vr.md
+++ b/.changeset/auto-enter-vr.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.7": minor
+---
+
+Add an `AutoEnterVR` config flag (#461). When enabled, the player checks for `immersive-vr` support after the video is initialized and requests the WebXR session automatically. Default is off. Note: browsers may require a user gesture to start a WebXR session; in flows where there is no pending gesture (for example, a fresh-page-load `AutoConnect`) the request can still be rejected and the player will log a warning.

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -33,6 +33,7 @@ export class Flags {
     static TouchInput = 'TouchInput' as const;
     static GamepadInput = 'GamepadInput' as const;
     static XRControllerInput = 'XRControllerInput' as const;
+    static AutoEnterVR = 'AutoEnterVR' as const;
     static WaitForStreamer = 'WaitForStreamer' as const;
     static HideUI = 'HideUI' as const;
     static EnableCaptureTimeExt = 'EnableCaptureTimeExt' as const;
@@ -540,6 +541,19 @@ export class Config {
                 settings && Object.prototype.hasOwnProperty.call(settings, Flags.XRControllerInput)
                     ? settings[Flags.XRControllerInput]
                     : true,
+                useUrlParams
+            )
+        );
+
+        this.flags.set(
+            Flags.AutoEnterVR,
+            new SettingFlag(
+                Flags.AutoEnterVR,
+                'Auto enter VR',
+                'When the video is ready and an immersive-vr session is supported, request the WebXR session automatically. May fail if the browser requires a user gesture to start a WebXR session.',
+                settings && Object.prototype.hasOwnProperty.call(settings, Flags.AutoEnterVR)
+                    ? settings[Flags.AutoEnterVR]
+                    : false,
                 useUrlParams
             )
         );

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -518,6 +518,32 @@ export class PixelStreaming {
     _onVideoInitialized() {
         this._eventEmitter.dispatchEvent(new VideoInitializedEvent());
         this._videoStartTime = Date.now();
+        this.checkForAutoEnterVR();
+    }
+
+    /**
+     * If the AutoEnterVR flag is set and an immersive-vr session is supported,
+     * request the WebXR session. Browsers typically require a user gesture for
+     * `requestSession`; if no gesture is currently active the request will be
+     * rejected and a warning is logged. Callers that need a guaranteed entry
+     * (e.g. AutoConnect from a fresh page load) should still wire up a button.
+     */
+    private checkForAutoEnterVR() {
+        if (!this.config.isFlagEnabled(Flags.AutoEnterVR)) {
+            return;
+        }
+        WebXRController.isSessionSupported('immersive-vr')
+            .then((supported: boolean) => {
+                if (!supported) {
+                    Logger.Info('AutoEnterVR is on but immersive-vr is not supported on this device.');
+                    return;
+                }
+                this._webXrController.xrClicked();
+            })
+            .catch((err: unknown) => {
+                const msg = err instanceof Error ? err.message : JSON.stringify(err);
+                Logger.Warning(`AutoEnterVR check failed: ${msg}`);
+            });
     }
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [feat(frontend): add AutoEnterVR config flag (#461) (#850)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/850)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)