### PR TITLE
[UE5.5] fix(frontend): keep tracking mouse drags outside the video element (#349) (#848)

### DIFF
--- a/.changeset/mouse-capture-outside-video.md
+++ b/.changeset/mouse-capture-outside-video.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.7": patch
+---
+
+Fix mouse-button-held tracking so dragging outside the video element keeps sending move and release events to UE (#349). When a button is pressed on the hovering mouse controller, `mousemove`/`mouseup` are temporarily moved from the video element to `window`, with coordinates re-computed against the video element's bounding rect. When all buttons are released, the listeners switch back to the element. This prevents the engine from being left with a stuck button when the user releases outside the video — common with `DefaultViewportMouseCaptureMode=CaptureDuringMouseDown`.

--- a/Frontend/library/src/Inputs/MouseControllerHovering.ts
+++ b/Frontend/library/src/Inputs/MouseControllerHovering.ts
@@ -18,6 +18,13 @@ export class MouseControllerHovering extends MouseController {
     onMouseMoveListener: (event: MouseEvent) => void;
     onContextMenuListener: (event: MouseEvent) => void;
 
+    // Buttons currently held down. While non-empty, mousemove/mouseup are
+    // listened for on `window` rather than the video element so the press is
+    // tracked even when the cursor leaves the element. UE pairs every
+    // MouseDown with a later MouseUp; without this the engine can be left
+    // with a stuck button when the user releases outside the video element.
+    private pressedButtons = new Set<number>();
+
     constructor(
         streamMessageController: StreamMessageController,
         videoPlayer: VideoPlayer,
@@ -52,26 +59,73 @@ export class MouseControllerHovering extends MouseController {
         this.videoElementParent.removeEventListener('contextmenu', this.onContextMenuListener);
         this.videoElementParent.removeEventListener('wheel', this.onMouseWheelListener);
         this.videoElementParent.removeEventListener('dblclick', this.onMouseDblClickListener);
+        // If a button was held when unregister was called, clean up the
+        // window-level listeners too.
+        if (this.pressedButtons.size > 0) {
+            window.removeEventListener('mousemove', this.onMouseMoveListener);
+            window.removeEventListener('mouseup', this.onMouseUpListener);
+            this.pressedButtons.clear();
+        }
 
         super.unregister();
+    }
+
+    private startCapturing() {
+        // Move move/up listeners off the element and onto the window so they
+        // keep firing while the cursor is outside the video.
+        this.videoElementParent.removeEventListener('mousemove', this.onMouseMoveListener);
+        this.videoElementParent.removeEventListener('mouseup', this.onMouseUpListener);
+        window.addEventListener('mousemove', this.onMouseMoveListener);
+        window.addEventListener('mouseup', this.onMouseUpListener);
+    }
+
+    private stopCapturing() {
+        window.removeEventListener('mousemove', this.onMouseMoveListener);
+        window.removeEventListener('mouseup', this.onMouseUpListener);
+        this.videoElementParent.addEventListener('mousemove', this.onMouseMoveListener);
+        this.videoElementParent.addEventListener('mouseup', this.onMouseUpListener);
+    }
+
+    /**
+     * Compute (offsetX, offsetY) relative to the video element from a window-
+     * level event whose `target` may be any other element on the page.
+     */
+    private offsetFromVideo(event: MouseEvent): { x: number; y: number } {
+        if (event.currentTarget === this.videoElementParent) {
+            return { x: event.offsetX, y: event.offsetY };
+        }
+        const rect = this.videoElementParent.getBoundingClientRect();
+        return { x: event.clientX - rect.left, y: event.clientY - rect.top };
     }
 
     private onMouseDown(event: MouseEvent) {
         if (!this.videoPlayer.isVideoReady()) {
             return;
         }
-        const coord = this.coordinateConverter.translateUnsigned(event.offsetX, event.offsetY);
+        const off = this.offsetFromVideo(event);
+        const coord = this.coordinateConverter.translateUnsigned(off.x, off.y);
         this.streamMessageController.toStreamerHandlers.get('MouseDown')([event.button, coord.x, coord.y]);
         event.preventDefault();
+
+        if (this.pressedButtons.size === 0) {
+            this.startCapturing();
+        }
+        this.pressedButtons.add(event.button);
     }
 
     private onMouseUp(event: MouseEvent) {
         if (!this.videoPlayer.isVideoReady()) {
             return;
         }
-        const coord = this.coordinateConverter.translateUnsigned(event.offsetX, event.offsetY);
+        const off = this.offsetFromVideo(event);
+        const coord = this.coordinateConverter.translateUnsigned(off.x, off.y);
         this.streamMessageController.toStreamerHandlers.get('MouseUp')([event.button, coord.x, coord.y]);
         event.preventDefault();
+
+        this.pressedButtons.delete(event.button);
+        if (this.pressedButtons.size === 0) {
+            this.stopCapturing();
+        }
     }
 
     private onContextMenu(event: MouseEvent) {
@@ -85,7 +139,8 @@ export class MouseControllerHovering extends MouseController {
         if (!this.videoPlayer.isVideoReady()) {
             return;
         }
-        const coord = this.coordinateConverter.translateUnsigned(event.offsetX, event.offsetY);
+        const off = this.offsetFromVideo(event);
+        const coord = this.coordinateConverter.translateUnsigned(off.x, off.y);
         const delta = this.coordinateConverter.translateSigned(event.movementX, event.movementY);
         this.streamMessageController.toStreamerHandlers.get('MouseMove')([
             coord.x,
@@ -93,7 +148,12 @@ export class MouseControllerHovering extends MouseController {
             delta.x,
             delta.y
         ]);
-        event.preventDefault();
+        // Only call preventDefault when the event originated on the video
+        // element. On window-level events the target may be a page element
+        // for which preventDefault would be wrong.
+        if (event.currentTarget === this.videoElementParent) {
+            event.preventDefault();
+        }
     }
 
     private onMouseWheel(event: WheelEvent) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [fix(frontend): keep tracking mouse drags outside the video element (#349) (#848)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/848)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)