### PR TITLE
build(react): output bundle to its own dist/ instead of SignallingWebServer/www/

### DIFF
--- a/Frontend/implementations/react/readme.md
+++ b/Frontend/implementations/react/readme.md
@@ -15,3 +15,16 @@ To build and run the React application, run:
 - `npm install`
 - `npm run build-all`
 - `npm run serve`
+
+### Serving via Wilbur
+
+Webpack outputs this bundle to `Frontend/implementations/react/dist/` (rather than `SignallingWebServer/www/`, which is reserved for the TypeScript reference frontend). To have Wilbur serve the React bundle, pass its path via `--http_root`:
+
+```bash
+# Build the React bundle, then start Wilbur pointed at it
+npm run build --workspace Frontend/implementations/react
+./SignallingWebServer/platform_scripts/bash/start.sh \
+    --http_root="$(pwd)/Frontend/implementations/react/dist"
+```
+
+If you want webpack to write somewhere else (for example, to drop the bundle directly into a deploy directory), set `WEBPACK_OUTPUT_PATH` before running the build.

--- a/Frontend/implementations/react/webpack.common.js
+++ b/Frontend/implementations/react/webpack.common.js
@@ -59,7 +59,12 @@ module.exports = {
       filename: '[name].js',
       library: 'epicgames-react-frontend',
       libraryTarget: 'umd',
-      path: path.resolve(__dirname, '../../../SignallingWebServer/www'),
+      // Output to a local dist/ rather than SignallingWebServer/www so this build
+      // doesn't clobber the TypeScript reference frontend that Wilbur serves by default.
+      // To have Wilbur serve this bundle, point it at dist/ via --http_root.
+      path: process.env.WEBPACK_OUTPUT_PATH
+          ? path.resolve(process.env.WEBPACK_OUTPUT_PATH)
+          : path.resolve(__dirname, './dist'),
       clean: true,
       globalObject: 'this',
       hashFunction: 'xxhash64',
@@ -69,7 +74,7 @@ module.exports = {
     },
 	devServer: {
     	static: {
-    		directory: path.join(__dirname, '../../../SignallingWebServer/www'),
+    		directory: path.join(__dirname, './dist'),
     	},
     },
 }


### PR DESCRIPTION
## Summary

Both reference frontend implementations were writing to `SignallingWebServer/www/` with `clean: true`. `npm run build --ws` walks workspaces in declared order, so:

1. `Frontend/implementations/typescript` builds → writes `player.html`, `player.js`, all UI assets to `www/`.
2. `Frontend/implementations/react` builds → `clean: true` wipes everything the TS impl just wrote, then writes only `index.html` / `index.js`.

After that, `start.sh`'s `setup_frontend()` checks `if [ ! -d www ]` (`SignallingWebServer/platform_scripts/bash/common.sh:229`), sees `www/` exists, and skips its own rebuild. Wilbur ends up serving the React impl's minimal page — auto-connect, no overlay, white background — instead of the expected TS reference frontend with its `Click to start` overlay and settings UI.

The fix points the React webpack output at a local `dist/` directory. The two implementations no longer collide. `WEBPACK_OUTPUT_PATH` is honoured for symmetry with the TS impl, and the readme picks up a short note showing how to have Wilbur serve the React bundle via `--http_root`.

Repro before / verification after:

```
$ rm -rf SignallingWebServer/www \
         Frontend/implementations/react/dist \
         Frontend/implementations/typescript/dist
$ npm run build
$ ls SignallingWebServer/www/
# before: index.html  index.js  (React impl, TS impl gone)
# after:  player.html  player.js  showcase.html  stresstest.html  uiless.html ...
$ ls Frontend/implementations/react/dist/
# after:  index.html  index.js
```

## Test plan

- [x] `rm -rf` then `npm run build` at root — `www/` ends up with TS impl, React lands in its own `dist/`
- [x] Lint clean (`npm run lint --workspace Frontend/implementations/react`)
- [ ] Manual: `start.sh` after a root build serves the proper UI
- [ ] Manual: `start.sh --http_root=$(pwd)/Frontend/implementations/react/dist` serves the React impl