### PR TITLE
[UE5.5] fix(frontend): pair MouseDouble with a synthetic MouseUp release (#10) (#873)

### DIFF
--- a/.changeset/double-click-release.md
+++ b/.changeset/double-click-release.md
@@ -1,0 +1,6 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.7": patch
+"@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.7": patch
+---
+
+Synthesize a `MouseUp` after `MouseDouble` in both mouse controllers so the streamer's pressed-button state stays balanced after a double-click (#10). The plugin treats `MouseDouble` as a press-class event (`RoutePointerDoubleClickEvent` / `IGenericApplicationMessageHandler::OnMouseDoubleClick`) but never synthesizes a release; the browser's preceding `mouseup` was already consumed by the prior `MouseUp`, so UE was left thinking the button was still held — manifesting, for example, as camera pans that latched on after a double-click. Behaviour is gated on the new `MouseDoubleClickAutoRelease` flag (default on); disable it via `?MouseDoubleClickAutoRelease=false` or the settings panel to restore pre-fix behaviour for projects that handle the doubleclick release themselves.

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -30,6 +30,7 @@ export class Flags {
     static UseCamera = 'UseCamera' as const;
     static KeyboardInput = 'KeyboardInput' as const;
     static MouseInput = 'MouseInput' as const;
+    static MouseDoubleClickAutoRelease = 'MouseDoubleClickAutoRelease' as const;
     static TouchInput = 'TouchInput' as const;
     static GamepadInput = 'GamepadInput' as const;
     static XRControllerInput = 'XRControllerInput' as const;
@@ -499,6 +500,19 @@ export class Config {
                 'If enabled, send mouse events to streamer',
                 settings && Object.prototype.hasOwnProperty.call(settings, Flags.MouseInput)
                     ? settings[Flags.MouseInput]
+                    : true,
+                useUrlParams
+            )
+        );
+
+        this.flags.set(
+            Flags.MouseDoubleClickAutoRelease,
+            new SettingFlag(
+                Flags.MouseDoubleClickAutoRelease,
+                'Auto release after double-click',
+                'After sending a MouseDouble message, also send a matching MouseUp so the streamer’s pressed-button state stays balanced. Disable to restore pre-fix behaviour if your project handles the doubleclick release itself.',
+                settings && Object.prototype.hasOwnProperty.call(settings, Flags.MouseDoubleClickAutoRelease)
+                    ? settings[Flags.MouseDoubleClickAutoRelease]
                     : true,
                 useUrlParams
             )

--- a/Frontend/library/src/Inputs/InputClassesFactory.ts
+++ b/Frontend/library/src/Inputs/InputClassesFactory.ts
@@ -56,7 +56,7 @@ export class InputClassesFactory {
      * register mouse events based on a control type
      * @param controlScheme - if the mouse is either hovering or locked
      */
-    registerMouse(controlScheme: ControlSchemeType) {
+    registerMouse(controlScheme: ControlSchemeType, config: Config) {
         Logger.Info('Register Mouse Events');
         let mouseController: MouseController;
         if (controlScheme == ControlSchemeType.HoveringMouse) {
@@ -64,14 +64,16 @@ export class InputClassesFactory {
                 this.toStreamerMessagesProvider,
                 this.videoElementProvider,
                 this.coordinateConverter,
-                this.activeKeys
+                this.activeKeys,
+                config
             );
         } else {
             mouseController = new MouseControllerLocked(
                 this.toStreamerMessagesProvider,
                 this.videoElementProvider,
                 this.coordinateConverter,
-                this.activeKeys
+                this.activeKeys,
+                config
             );
         }
 

--- a/Frontend/library/src/Inputs/MouseController.ts
+++ b/Frontend/library/src/Inputs/MouseController.ts
@@ -5,6 +5,7 @@ import { InputCoordTranslator } from '../Util/InputCoordTranslator';
 import { VideoPlayer } from '../VideoPlayer/VideoPlayer';
 import type { ActiveKeys } from './InputClassesFactory';
 import { IInputController } from './IInputController';
+import { Config } from '../Config/Config';
 
 /**
  * Extra types for Document and WheelEvent
@@ -29,6 +30,7 @@ export class MouseController implements IInputController {
     streamMessageController: StreamMessageController;
     coordinateConverter: InputCoordTranslator;
     activeKeys: ActiveKeys;
+    config: Config;
 
     // bound listeners
     onEnterListener: (event: MouseEvent) => void;
@@ -38,12 +40,14 @@ export class MouseController implements IInputController {
         streamMessageController: StreamMessageController,
         videoPlayer: VideoPlayer,
         coordinateConverter: InputCoordTranslator,
-        activeKeys: ActiveKeys
+        activeKeys: ActiveKeys,
+        config: Config
     ) {
         this.streamMessageController = streamMessageController;
         this.coordinateConverter = coordinateConverter;
         this.videoPlayer = videoPlayer;
         this.activeKeys = activeKeys;
+        this.config = config;
 
         this.onEnterListener = this.onMouseEnter.bind(this);
         this.onLeaveListener = this.onMouseLeave.bind(this);

--- a/Frontend/library/src/Inputs/MouseControllerHovering.ts
+++ b/Frontend/library/src/Inputs/MouseControllerHovering.ts
@@ -4,6 +4,7 @@ import { InputCoordTranslator } from '../Util/InputCoordTranslator';
 import { VideoPlayer } from '../VideoPlayer/VideoPlayer';
 import type { ActiveKeys } from './InputClassesFactory';
 import { MouseController } from './MouseController';
+import { Config, Flags } from '../Config/Config';
 
 /**
  * A mouse controller that allows the mouse to freely float over the video document.
@@ -29,9 +30,10 @@ export class MouseControllerHovering extends MouseController {
         streamMessageController: StreamMessageController,
         videoPlayer: VideoPlayer,
         coordinateConverter: InputCoordTranslator,
-        activeKeys: ActiveKeys
+        activeKeys: ActiveKeys,
+        config: Config
     ) {
-        super(streamMessageController, videoPlayer, coordinateConverter, activeKeys);
+        super(streamMessageController, videoPlayer, coordinateConverter, activeKeys, config);
         this.videoElementParent = videoPlayer.getVideoParentElement() as HTMLDivElement;
         this.onMouseUpListener = this.onMouseUp.bind(this);
         this.onMouseDownListener = this.onMouseDown.bind(this);
@@ -175,5 +177,16 @@ export class MouseControllerHovering extends MouseController {
         }
         const coord = this.coordinateConverter.translateUnsigned(event.offsetX, event.offsetY);
         this.streamMessageController.toStreamerHandlers.get('MouseDouble')([event.button, coord.x, coord.y]);
+
+        // The streamer plugin treats `MouseDouble` as a press-class event (it routes to
+        // Slate's RoutePointerDoubleClickEvent / IGenericApplicationMessageHandler::OnMouseDoubleClick)
+        // but never synthesizes the matching release. The browser's preceding `mouseup` was
+        // already consumed by the prior `MouseUp` message, so without this UE is left thinking
+        // the button is still held — manifesting as e.g. camera pans that latch on after a
+        // double-click. See issue #10.
+        // Disable Flags.MouseDoubleClickAutoRelease to restore the pre-fix behaviour.
+        if (this.config.isFlagEnabled(Flags.MouseDoubleClickAutoRelease)) {
+            this.streamMessageController.toStreamerHandlers.get('MouseUp')([event.button, coord.x, coord.y]);
+        }
     }
 }

--- a/Frontend/library/src/Inputs/MouseControllerLocked.ts
+++ b/Frontend/library/src/Inputs/MouseControllerLocked.ts
@@ -5,6 +5,7 @@ import { InputCoordTranslator, TranslatedCoordUnsigned } from '../Util/InputCoor
 import { VideoPlayer } from '../VideoPlayer/VideoPlayer';
 import type { ActiveKeys } from './InputClassesFactory';
 import { MouseController } from './MouseController';
+import { Config, Flags } from '../Config/Config';
 
 /**
  * A mouse controller that locks the mouse to the video document and prevents it from leaving the window
@@ -28,9 +29,10 @@ export class MouseControllerLocked extends MouseController {
         streamMessageController: StreamMessageController,
         videoPlayer: VideoPlayer,
         coordinateConverter: InputCoordTranslator,
-        activeKeys: ActiveKeys
+        activeKeys: ActiveKeys,
+        config: Config
     ) {
-        super(streamMessageController, videoPlayer, coordinateConverter, activeKeys);
+        super(streamMessageController, videoPlayer, coordinateConverter, activeKeys, config);
         this.videoElementParent = videoPlayer.getVideoParentElement() as HTMLDivElement;
         this.x = this.videoElementParent.getBoundingClientRect().width / 2;
         this.y = this.videoElementParent.getBoundingClientRect().height / 2;
@@ -191,5 +193,20 @@ export class MouseControllerLocked extends MouseController {
             this.normalizedCoord.x,
             this.normalizedCoord.y
         ]);
+
+        // The streamer plugin treats `MouseDouble` as a press-class event (it routes to
+        // Slate's RoutePointerDoubleClickEvent / IGenericApplicationMessageHandler::OnMouseDoubleClick)
+        // but never synthesizes the matching release. The browser's preceding `mouseup` was
+        // already consumed by the prior `MouseUp` message, so without this UE is left thinking
+        // the button is still held — manifesting as e.g. camera pans that latch on after a
+        // double-click. See issue #10.
+        // Disable Flags.MouseDoubleClickAutoRelease to restore the pre-fix behaviour.
+        if (this.config.isFlagEnabled(Flags.MouseDoubleClickAutoRelease)) {
+            this.streamMessageController.toStreamerHandlers.get('MouseUp')([
+                event.button,
+                this.normalizedCoord.x,
+                this.normalizedCoord.y
+            ]);
+        }
     }
 }

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1952,7 +1952,7 @@ export class WebRtcPlayerController {
             const mouseMode = this.config.isFlagEnabled(Flags.HoveringMouseMode)
                 ? ControlSchemeType.HoveringMouse
                 : ControlSchemeType.LockedMouse;
-            this.mouseController = this.inputClassesFactory.registerMouse(mouseMode);
+            this.mouseController = this.inputClassesFactory.registerMouse(mouseMode, this.config);
         }
     }
 

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -220,6 +220,12 @@ export class ConfigUI {
             if (isSettingEnabled(settingsConfig, Flags.MouseInput))
                 this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.MouseInput));
 
+            if (isSettingEnabled(settingsConfig, Flags.MouseDoubleClickAutoRelease))
+                this.addSettingFlag(
+                    inputSettingsSection,
+                    this.flagsUi.get(Flags.MouseDoubleClickAutoRelease)
+                );
+
             if (isSettingEnabled(settingsConfig, Flags.FakeMouseWithTouches))
                 this.addSettingFlag(inputSettingsSection, this.flagsUi.get(Flags.FakeMouseWithTouches));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [fix(frontend): pair MouseDouble with a synthetic MouseUp release (#10) (#873)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/873)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)