### PR TITLE
[UE5.6] build(react): output bundle to its own dist/ instead of SignallingWebServer/www/ (#874)

### DIFF
--- a/Frontend/implementations/react/readme.md
+++ b/Frontend/implementations/react/readme.md
@@ -15,3 +15,16 @@ To build and run the React application, run:
 - `npm install`
 - `npm run build-all`
 - `npm run serve`
+
+### Serving via Wilbur
+
+Webpack outputs this bundle to `Frontend/implementations/react/dist/` (rather than `SignallingWebServer/www/`, which is reserved for the TypeScript reference frontend). To have Wilbur serve the React bundle, pass its path via `--http_root`:
+
+```bash
+# Build the React bundle, then start Wilbur pointed at it
+npm run build --workspace Frontend/implementations/react
+./SignallingWebServer/platform_scripts/bash/start.sh \
+    --http_root="$(pwd)/Frontend/implementations/react/dist"
+```
+
+If you want webpack to write somewhere else (for example, to drop the bundle directly into a deploy directory), set `WEBPACK_OUTPUT_PATH` before running the build.

--- a/Frontend/implementations/react/webpack.common.js
+++ b/Frontend/implementations/react/webpack.common.js
@@ -59,7 +59,12 @@ module.exports = {
       filename: '[name].js',
       library: 'epicgames-react-frontend',
       libraryTarget: 'umd',
-      path: path.resolve(__dirname, '../../../SignallingWebServer/www'),
+      // Output to a local dist/ rather than SignallingWebServer/www so this build
+      // doesn't clobber the TypeScript reference frontend that Wilbur serves by default.
+      // To have Wilbur serve this bundle, point it at dist/ via --http_root.
+      path: process.env.WEBPACK_OUTPUT_PATH
+          ? path.resolve(process.env.WEBPACK_OUTPUT_PATH)
+          : path.resolve(__dirname, './dist'),
       clean: true,
       globalObject: 'this',
       hashFunction: 'xxhash64',
@@ -69,7 +74,7 @@ module.exports = {
     },
 	devServer: {
     	static: {
-    		directory: path.join(__dirname, '../../../SignallingWebServer/www'),
+    		directory: path.join(__dirname, './dist'),
     	},
     },
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.6`:
 - [build(react): output bundle to its own dist/ instead of SignallingWebServer/www/ (#874)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/874)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)