### PR TITLE
feat(wilbur): add /health endpoint for load balancer routing

### DIFF
--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
@@ -328,6 +328,14 @@ if (shouldServerStart) {
 
 const signallingServer = new SignallingServer(serverOpts);
 
+app.get('/health', (_req: express.Request, res: express.Response) => {
+    if (signallingServer.playerRegistry.count() > 0) {
+        res.sendStatus(503);
+    } else {
+        res.sendStatus(200);
+    }
+});
+
 if (options.stdin) {
     initInputHandler(options, signallingServer);
 }
@@ -351,3 +359,5 @@ if (options.rest_api) {
         }
     }).catch((err: unknown) => Logger.error(`REST API initialization failed: ${String(err)}`));
 }
+
+


### PR DESCRIPTION
  Returns 200 when no player is connected, 503 when one is. Allows an
  Azure load balancer health probe to remove busy servers from the pool.

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
What problem does this PR address?

## Solution
How does this PR solve the problem?

## Documentation
If you added a new feature or changed an existing feature please add some documentation here.

Or better yet, link to the relevant `/Docs` update in your PR.

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compataibility with the existing functionality? 

Or better yet, link to the unit tests that accompany this PR.
