### PR TITLE
fix(typescript-impl): drop webpack experiments.futureDefaults

### DIFF
--- a/Frontend/implementations/typescript/webpack.base.js
+++ b/Frontend/implementations/typescript/webpack.base.js
@@ -67,9 +67,6 @@ module.exports = {
       globalObject: 'this',
       hashFunction: 'xxhash64',
     },
-    experiments: {
-      futureDefaults: true
-    },
 	devServer: {
     	static: {
     		directory: path.join(__dirname, '../../../SignallingWebServer/www'),


### PR DESCRIPTION
## Summary
- Drop `experiments: { futureDefaults: true }` from `Frontend/implementations/typescript/webpack.base.js`.
- Restores the build of the TypeScript reference implementation, which has been failing on master and every open PR for several days.

## Background

`futureDefaults` enables several webpack-5-future behaviours including strict URL-scheme handling. With it on, the `HtmlWebpackPlugin` child compilations for `player.html` / `showcase.html` / `uiless.html` / `stresstest.html` attempt to resolve the `<link href="https://fonts.googleapis.com/...">` tags in those templates as module imports. Webpack has no handler for the `https:` scheme, so the build fails with:

```
UnhandledSchemeError: Reading from "https://fonts.googleapis.com/css2" is not handled by plugins (Unhandled scheme).
Module not found: Error: Can't resolve '${___HTML_LOADER_IMPORT_0___}' in '/.../Frontend/implementations/typescript/src'
Conflict: Multiple assets emit different content to the same filename uiless.html
```

26 errors total, repeated across `player`, `showcase`, `stresstest`, `uiless`. The external font URLs are meant to be fetched by the browser at runtime, not bundled — and that's what happens without the flag.

The break landed sometime between 2026-05-24 (last green CI on a dependabot PR) and now. I haven't bisected which transitive dep update flipped `futureDefaults`'s behaviour, but the fix is localised and well-isolated: removing the flag restores the prior, working behaviour. Same approach is consistent with how `Frontend/implementations/react/webpack.common.js` is configured (no `futureDefaults`).

## Test plan

From `Frontend/implementations/typescript`:
- [x] `npm run build:dev` — `webpack 5.107.1 compiled successfully in 2187 ms`
- [x] `npm run build:prod` — exit 0, all assets emitted to `SignallingWebServer/www/`
- [x] `npm run build:esm` — `compiled successfully in 2076 ms`
- [x] Emitted `player.html` and `showcase.html` retain the `<link href="https://fonts.googleapis.com/...">` tags verbatim, so the browser fetches the fonts at runtime (the intended behaviour).
- [x] Local asset references (`images/favicon-*.png`, `css/showcase.css`, the bundled `player.js`/`showcase.js`) resolve and emit correctly.

## Not in scope

- Pinning the Dockerfile base from `node:lts` to `node:22.14.0-bookworm` to match `NODE_VERSION`. The build also fails locally on Node 22.14.0, so the docker drift didn't cause this failure — but pinning is still a worthwhile follow-up for reproducibility.