### PR TITLE
[UE5.7] fix(typescript-impl): drop webpack experiments.futureDefaults (#886)

### DIFF
--- a/Frontend/implementations/typescript/webpack.base.js
+++ b/Frontend/implementations/typescript/webpack.base.js
@@ -67,9 +67,6 @@ module.exports = {
       globalObject: 'this',
       hashFunction: 'xxhash64',
     },
-    experiments: {
-      futureDefaults: true
-    },
 	devServer: {
     	static: {
     		directory: path.join(__dirname, '../../../SignallingWebServer/www'),


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [fix(typescript-impl): drop webpack experiments.futureDefaults (#886)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/886)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)