### PR TITLE
[UE5.5] fix: override vulnerable transitive deps for dependabot alerts (#884)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,12 @@
         "tar": "7.5.11",
         "handlebars": "4.7.9",
         "test-exclude": "^7.0.2",
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.0",
+        "ws@^8": "^8.20.1",
+        "qs@^6": "^6.15.2",
+        "webpack-dev-server@^5": "^5.2.4",
+        "brace-expansion@^5": "^5.0.6",
+        "fast-uri@^3": "^3.1.2"
     },
     "dependencies": {
         "fs-routes": "^12.1.3"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [fix: override vulnerable transitive deps for dependabot alerts (#884)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/884)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)