### PR TITLE
[UE5.7] fix: override vulnerable transitive deps for dependabot alerts (#884)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -850,29 +850,17 @@
                 "typescript": "5.4.5"
             }
         },
-        "node_modules/@bufbuild/protoplugin/node_modules/@typescript/vfs": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
-            "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.4.3"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            }
-        },
         "node_modules/@bufbuild/protoplugin/node_modules/typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/@changesets/apply-release-plan": {
@@ -4261,6 +4249,18 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript/vfs": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
+            "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3"
+            },
+            "peerDependencies": {
+                "typescript": "*"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -16529,7 +16529,6 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
         "handlebars": "4.7.9",
         "test-exclude": "^7.0.2",
         "uuid": "^14.0.0",
-        "@protobuf-ts/plugin": {
-            "typescript": "3.9.10"
-        }
+        "ws@^8": "^8.20.1",
+        "qs@^6": "^6.15.2",
+        "webpack-dev-server@^5": "^5.2.4",
+        "brace-expansion@^5": "^5.0.6",
+        "fast-uri@^3": "^3.1.2"
     },
     "dependencies": {}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [fix: override vulnerable transitive deps for dependabot alerts (#884)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/884)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)