### PR TITLE
ci: prune changesets from master after merge

### DIFF
--- a/.github/scripts/prune-master-changesets.sh
+++ b/.github/scripts/prune-master-changesets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Remove changeset files from master.
+#
+# Changesets are authored on master, but master never runs `changeset version`
+# (only the UE* release branches do). The introducing PR's commit -- which
+# contains the changeset -- is permanent in master's history, and the backport
+# action (sorenlouv/backport-github-action) cherry-picks THAT commit onto each
+# release branch, where the changeset is consumed. So master's working-tree
+# copy is functionless the moment the PR merges and can be deleted; release
+# branches still receive it via cherry-pick from history, regardless of
+# master's current tree -- even for backports labelled days later.
+#
+# This deliberately does NOT inspect release-branch state: downstream delivery
+# does not depend on the file's presence on master, so there is nothing to wait
+# for. The introducing PR must of course CONTAIN the changeset (that is what
+# lands it in history); this cleanup is always a separate follow-up and must
+# never carry an auto-backport label.
+#
+# Environment:
+#   PRUNE_BODY_PATH   If set, a markdown PR body is written here.
+#   GITHUB_OUTPUT     If set, "removed_count=N" is appended (GitHub Actions).
+#
+# Assumes: run from the repo root on a checkout of master.
+set -euo pipefail
+
+body_path="${PRUNE_BODY_PATH:-}"
+if [[ -n "$body_path" ]]; then
+    {
+        echo "Automated cleanup. master never consumes changesets; release branches receive them via cherry-pick of the introducing commit, so these working-tree copies are redundant and safe to remove."
+        echo
+        echo "## Removed changesets"
+    } > "$body_path"
+fi
+
+removed=0
+shopt -s nullglob
+for f in .changeset/*.md; do
+    base="$(basename "$f")"
+    [[ "$base" == "README.md" ]] && continue
+    echo "  remove  $base"
+    git rm -q "$f"
+    [[ -n "$body_path" ]] && echo "- \`$base\`" >> "$body_path"
+    removed=$(( removed + 1 ))
+done
+
+echo "Removed ${removed} changeset(s)."
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "removed_count=${removed}" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/changesets-prune-master.yml
+++ b/.github/workflows/changesets-prune-master.yml
@@ -1,0 +1,53 @@
+name: Prune Master Changesets
+
+# Changesets are authored on master, but master never runs `changeset version`
+# (only the UE* release branches do). Backports cherry-pick the introducing
+# commit -- which carries the changeset from history -- onto each release
+# branch, so master's working-tree copies are redundant the moment a PR merges.
+# This job removes them and surfaces the deletions as a single, continuously-
+# updated cleanup PR (fixed branch -> the existing PR is refreshed in place
+# rather than duplicated).
+on:
+  push:
+    branches: [master]
+    paths: ['.changeset/*.md'] # a merged PR that added a changeset
+  schedule:
+    - cron: '17 4 * * 1' # weekly backstop in case a push event is missed
+  workflow_dispatch:
+
+# Never run two prune jobs at once (they share the cleanup branch).
+concurrency: prune-master-changesets
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prune:
+    name: Prune
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Prune changesets
+        id: prune
+        env:
+          PRUNE_BODY_PATH: ${{ runner.temp }}/prune-body.md
+        run: bash .github/scripts/prune-master-changesets.sh
+
+      # Fixed branch: peter-evans reuses an open PR if one exists, so an
+      # unmerged cleanup PR is refreshed in place rather than duplicated.
+      - name: Create or update cleanup PR
+        if: steps.prune.outputs.removed_count != '0'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: master
+          branch: automated/prune-changesets
+          delete-branch: true
+          title: 'chore: prune changesets from master'
+          commit-message: 'chore: prune changesets from master'
+          body-path: ${{ runner.temp }}/prune-body.md


### PR DESCRIPTION
## Problem

Master accumulates stale changeset files. Changesets are authored on `master`, but `master` never runs `changeset version` — only the `UE*` release branches do (`changesets-update-changelogs.yml` triggers on `branches: ['UE*']`). So master's changesets are never consumed and `.changeset/` grows without bound (currently 11 files).

## Why master's copy is redundant

Backports use `sorenlouv/backport-github-action`, which **cherry-picks the introducing PR's commit** onto each release branch — it never tree-merges master. That commit contains the changeset and lives in master's history permanently, so:

- Release branches receive the changeset via cherry-pick **from history**, regardless of whether master still has the file.
- This holds even when the `auto-backport-to-*` label is added days later (the action also triggers on `labeled`) and when a failed backport is redone manually (`git cherry-pick <sha>`).

So once the introducing PR merges, master's working-tree copy serves no function (master never consumes changesets itself) and can be deleted.

## Approach

A workflow removes changesets from master and opens a **single, continuously-updated cleanup PR** (fixed branch `automated/prune-changesets` via `peter-evans/create-pull-request`, so an unmerged PR is refreshed in place, never duplicated). Triggers: push to master touching `.changeset/*.md`, a weekly backstop, and manual dispatch.

No release-branch inspection and no grace period — downstream delivery doesn't depend on the file being on master, so there's nothing to wait for.

## Guard rails

- The cleanup is always a **separate follow-up** PR; the introducing PR must still contain the changeset (that's what lands it in history for the cherry-pick).
- The cleanup PR must **never** carry an `auto-backport` label (it's bot-created without labels), or it would try to cherry-pick *deletions* onto release branches.

## Note / tradeoff

Master loses the at-a-glance "pending backport" signal and master-only changesets get reaped promptly — both fine, since backport status is tracked by the backport PRs and master never releases anything.

## Testing

Dry-run against current master (`git rm` stubbed): cleanly proposes removing all 11 changesets, with the generated PR body listing each.