### PR TITLE
[UE5.8] chore: update org references from EpicGamesExt to EpicGames (#901)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,5 @@
 {
-    "repoOwner": "EpicGamesExt",
+    "repoOwner": "EpicGames",
     "repoName": "PixelStreamingInfrastructure",
     "targetBranchChoices": ["master", "UE5.2", "UE5.3", "UE5.4", "UE5.5", "UE5.6", "UE5.7", "UE5.8"],
     "autoMerge": true,

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   streaming-test-linux:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
@@ -42,7 +42,7 @@ jobs:
         path: Extras/FrontendTests/results
 
   # streaming-test-win:
-  #   if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
   #   runs-on: windows-latest
   #   steps:
   #   - name: Checkout source code
@@ -59,7 +59,7 @@ jobs:
   #   - name: Download streamer
   #     uses: robinraju/release-downloader@v1
   #     with:
-  #       repository: 'EpicGamesExt/PixelStreamingInfrastructure'
+  #       repository: 'EpicGames/PixelStreamingInfrastructure'
   #       tag: 'minimal-streamer'
   #       fileName: 'Minimal-PixelStreamer-5.6.7z'
   #

--- a/.github/workflows/healthcheck-image-sfu.yml
+++ b/.github/workflows/healthcheck-image-sfu.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-image-wilbur.yml
+++ b/.github/workflows/healthcheck-image-wilbur.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-using-local-deps:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   linkChecker:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-script-linux:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -24,7 +24,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-macos:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: macos-latest
     steps:
       - name: Checkout source code
@@ -36,7 +36,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-windows:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: windows-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/healthcheck-signalling-protocol.yml
+++ b/.github/workflows/healthcheck-signalling-protocol.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   signalling-protocol-test:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   # Uncomment when we can Linux test to capture a non-black screenshot using software renderer.
   # streaming-test-linux:
-  #   if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout source code
@@ -46,7 +46,7 @@ jobs:
   #       path: Extras/MinimalStreamTester/results
 
   streaming-test-win:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: windows-latest
     steps:
     - name: Checkout source code
@@ -64,7 +64,7 @@ jobs:
     - name: Download streamer
       uses: robinraju/release-downloader@v1
       with:
-        repository: 'EpicGamesExt/PixelStreamingInfrastructure'
+        repository: 'EpicGames/PixelStreamingInfrastructure'
         tag: 'minimal-streamer-5.7'
         fileName: 'Minimal-PixelStreamer-5.7-Win64-Development.7z'
 

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Please remain patient, courteous, and professional at all times. Any form of spa
 ### Creating issues
 
 If you have encountered a bug, have suggestions for our documentation or infrastructure, or would like to propose a feature that could enhance Pixel Streaming in various use case scenarios, you can raise this with us by creating a new issue.
-1. First, search all open and closed issues [here](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues?q=is%3Aissue+) or in the [legacy repository](https://github.com/EpicGames/PixelStreamingInfrastructure/issues?q=is%3Aissue+is%3Aclosed) - your issue may have already been discussed or addressed.
-2. If your issue doesn't exist, open a new issue [here](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues/new/choose) by selecting a bug or feature request.
+1. First, search all open and closed issues [here](https://github.com/EpicGames/PixelStreamingInfrastructure/issues?q=is%3Aissue+) or in the [legacy repository](https://github.com/EpicGames/PixelStreamingInfrastructure/issues?q=is%3Aissue+is%3Aclosed) - your issue may have already been discussed or addressed.
+2. If your issue doesn't exist, open a new issue [here](https://github.com/EpicGames/PixelStreamingInfrastructure/issues/new/choose) by selecting a bug or feature request.
 3. Make sure to fill in the template as much as possible; any information you can provide, such as repro steps, crash stacks, screenshots, etc., can help us triage and fix the problem as quickly as possible.
 4. Keep an eye on the status of your issue; our developers or other users might reach out with requests for more information. If this happens, issues that have not received a response in over 30 days will be automatically closed.
 5. Be patient while waiting on a resolution; we prioritize the issues internally and some less critical features (however much we'd love to implement them!) will take a backseat to more pressing priorities, so some issues can take a while to get resolved.
@@ -27,12 +27,12 @@ If you have a solution to a problem you've encountered or to any other open issu
 1. Fork the repo and branch off of the `main` branch in your fork.
 2. Implement your changes in your branch and make sure your commits are Verified! Signed commits are required for merging! [Github Signing Documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
 3. Do as much testing as you can, and when you are happy, tidy up your work and commit the update.
-4. Create a [pull request](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pulls) and don't forget to link it to an issue if there's an existing one. Add as much information as possible to your PR: describe the problem your change solves, mention any testing you have done and attach any relevant documents and screenshots.
+4. Create a [pull request](https://github.com/EpicGames/PixelStreamingInfrastructure/pulls) and don't forget to link it to an issue if there's an existing one. Add as much information as possible to your PR: describe the problem your change solves, mention any testing you have done and attach any relevant documents and screenshots.
 5. If your are contributing a PR for a new feature, we strongly encourage you to accompany it with relevant documentation and a detailed description of the tests you have done. PRs that don't have this information may take a long time to be addressed, since our team will have to do the testing.
 6. If your PR is good to go, we will merge it in. Woohoo! Thank you for your time and efforts! 🎉
 7. Keep a close eye on your PR - quite often, our developers will review your PR and leave comments; we might request some minor code changes and modifications, style unification, or leave any general comments and questions that are preventing us from merging the PR.
 8. If we do not hear from you after requesting more information within 30 days, the PR will auto-close. In this case, we might elect to open our own PR and re-use some of the changes that you proposed, supplemented with anything else that was required to be added in your original PR.
-9. If your PR fixes a problem in the previous [still-supported UE branches](https://github.com/EpicGamesExt/PixelStreamingInfrastructure#versions), feel free to add the `auto-backport` and `auto-backport-to-UEX.X` labels. You'll need to add a `auto-backport-to-UEX.X` label for each branch you wish your change to be merged back to. Note that if a change to any of the previous branches is not trivial and requires a lot of testing and compatibility checks, we might elect to close it if we do not think that it brings enough value to the branch.
+9. If your PR fixes a problem in the previous [still-supported UE branches](https://github.com/EpicGames/PixelStreamingInfrastructure#versions), feel free to add the `auto-backport` and `auto-backport-to-UEX.X` labels. You'll need to add a `auto-backport-to-UEX.X` label for each branch you wish your change to be merged back to. Note that if a change to any of the previous branches is not trivial and requires a lot of testing and compatibility checks, we might elect to close it if we do not think that it brings enough value to the branch.
 
 #### Note about changesets
 
@@ -46,7 +46,7 @@ To create a changeset with your PR
 ### Other ways to contribute
 
 - Keep an eye on our repo and stay active on existing issues and PRs; you can help by adding informative comments to the discussions, additional repro steps, repros in different environments, or any suggestions as to what could be causing the issue and how it could be solved.
-- Work on [issues labeled for community](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). We specifically created this label to mark issues that we would love the community to help us with.
+- Work on [issues labeled for community](https://github.com/EpicGames/PixelStreamingInfrastructure/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). We specifically created this label to mark issues that we would love the community to help us with.
 - Create documentation for undocumented features. Please open an issue first, so our developers can provide you with some guidance.
 - Write more unit test coverage.
 - Document functions in the public API that are not documented.
@@ -58,7 +58,7 @@ To create a changeset with your PR
  - All TypeScript should pass our `npm run lint`.
  - Names should follow US English spelling.
  - All public functions/API should have comments.
- - Code formatting should adhere to the following [whitespace and indentation rules](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/.prettierrc.json).
+ - Code formatting should adhere to the following [whitespace and indentation rules](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/.prettierrc.json).
  - All new features should have accompanying unit tests and documentation when they are submitted.
  - Prefer early returns in `if` statements to decrease indentation.
  - Prefer functions to not exceed ~20 lines.

--- a/Common/README.md
+++ b/Common/README.md
@@ -3,15 +3,15 @@
 This library exposes common functionality for Pixel Streaming web applications. Examples include message protocols, logging, events, and various utilities.
 
 For examples of how to implement this library, see:
-- [lib-pixelstreamingfrontend](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master/Frontend/library)
-- [lib-pixelstreamingsignalling](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master/Signalling)
-- [Wilbur](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master/SignallingWebServer) (the reference Pixel Streaming signalling server)
+- [lib-pixelstreamingfrontend](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Frontend/library)
+- [lib-pixelstreamingsignalling](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Signalling)
+- [Wilbur](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/SignallingWebServer) (the reference Pixel Streaming signalling server)
 
 ### Adding it to your project
 `npm i @epicgames-ps/lib-pixelstreamingcommon-ue5.5`
 
 ## Documentation
-The API is documented [here](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master/Common/docs).
+The API is documented [here](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Common/docs).
 
 ### NPM package contents
 - ES6 modules

--- a/Common/package.json
+++ b/Common/package.json
@@ -46,7 +46,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure"
+        "url": "https://github.com/EpicGames/PixelStreamingInfrastructure"
     },
     "publishConfig": {
         "access": "public"

--- a/Extras/mediasoup-sdp-bridge/package.json
+++ b/Extras/mediasoup-sdp-bridge/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure.git"
+    "url": "https://github.com/EpicGames/PixelStreamingInfrastructure.git"
   },
   "funding": {
     "type": "opencollective",

--- a/Frontend/Docs/Timing Out Inactive Connections.md
+++ b/Frontend/Docs/Timing Out Inactive Connections.md
@@ -12,7 +12,7 @@ If the user continues not to respond, the AFK system waits 10 more seconds befor
 
 Any user interaction with the player panel resets the AFK timer. This includes mouse moves and drags, mouse button presses, keyboard presses, touch events on mobile devices, and custom interactions you set up with the `emitCommand` and `emitUIInteraction` functions.
 
-To use the AFK system, set the following properties in the [`Config`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/library/src/Config/Config.ts) object passed used to create a [`PixelStreaming`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/library/src/PixelStreaming/PixelStreaming.ts) stream.
+To use the AFK system, set the following properties in the [`Config`](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Frontend/library/src/Config/Config.ts) object passed used to create a [`PixelStreaming`](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Frontend/library/src/PixelStreaming/PixelStreaming.ts) stream.
 
 | Property | Default | Description |
 |    ---   |   ---   |     ---     |
@@ -32,4 +32,4 @@ const stream = new PixelStreaming(config);
 ```
 
 **_Tip:_**
-If you want to customize the content of the overlay, you can replace the [`AFKOverlay`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/ui-library/src/Overlay/AFKOverlay.ts) class. You must then also extend the [`Application`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/ui-library/src/Application/Application.ts) class in order to use the new overlay.
+If you want to customize the content of the overlay, you can replace the [`AFKOverlay`](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Frontend/ui-library/src/Overlay/AFKOverlay.ts) class. You must then also extend the [`Application`](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Frontend/ui-library/src/Application/Application.ts) class in order to use the new overlay.

--- a/Frontend/Docs/Typing into streamed text inputs.md
+++ b/Frontend/Docs/Typing into streamed text inputs.md
@@ -1,6 +1,6 @@
 # Typing into streamed inputs
 
-Since [PR564](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/564) there has been improved support for typing into streamed text widgets from Unreal Engine.
+Since [PR564](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/564) there has been improved support for typing into streamed text widgets from Unreal Engine.
 
 Out the box the following is supported:
 

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -30,7 +30,7 @@ If part of the library is not exposed and you wish to extend it, please do so in
 
 ## Developing
 
-⚠️ Only [this](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/NODE_VERSION) NodeJS version is officially supported, other versions may **BREAK YOUR BUILD** ⚠️
+⚠️ Only [this](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/NODE_VERSION) NodeJS version is officially supported, other versions may **BREAK YOUR BUILD** ⚠️
 
 ### Prerequisites for local dev
 - Install NodeJS version specified above.

--- a/Frontend/implementations/typescript/package.json
+++ b/Frontend/implementations/typescript/package.json
@@ -29,6 +29,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure"
+        "url": "https://github.com/EpicGames/PixelStreamingInfrastructure"
     }
 }

--- a/Frontend/implementations/typescript/readme.md
+++ b/Frontend/implementations/typescript/readme.md
@@ -4,7 +4,7 @@ This is the stock look-and-feel Pixel Streaming player web page you are served o
 
 **This is great starting point for building your UI or studying the Pixel Streaming feature set.**
 
-![Frontend](https://raw.githubusercontent.com/EpicGamesExt/PixelStreamingInfrastructure/0aabae464daa95925cf6fa238ac18d0a5561a421/Frontend/implementations/EpicGames/docs/images/frontend.jpg)
+![Frontend](https://raw.githubusercontent.com/EpicGames/PixelStreamingInfrastructure/0aabae464daa95925cf6fa238ac18d0a5561a421/Frontend/implementations/EpicGames/docs/images/frontend.jpg)
 
 The reference frontend uses:
 
@@ -17,7 +17,7 @@ This package is also a good example of how to include the frontend libraries as 
 
 ### Key features of the reference frontend
 - An info panel (screen right) that provides a UI for displaying live statistics to the user.
-- A settings panel (screen right) that provides a UI for all the [settings](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Frontend/Docs/Settings%20Panel.md).
+- A settings panel (screen right) that provides a UI for all the [settings](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Frontend/Docs/Settings%20Panel.md).
 - A set of controls (screen left) to maximize the video, open the settings panel, open the info panel, and enter VR mode.
 - Ability to display overlays that present information or errors to the user, or present prompts for the user to interact with.
 

--- a/Frontend/library/package.json
+++ b/Frontend/library/package.json
@@ -38,7 +38,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure"
+        "url": "https://github.com/EpicGames/PixelStreamingInfrastructure"
     },
     "author": "Epic Games",
     "license": "MIT",

--- a/Frontend/library/readme.md
+++ b/Frontend/library/readme.md
@@ -2,7 +2,7 @@
 
 The core library for the browser/client side of Pixel Streaming experiences. **This library contains no UI.**
 
-See the [reference Pixel Streaming web player](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master/Frontend/implementations/typescript) for an example of how to build a Pixel Streaming web application, with custom UI, on top of this library.
+See the [reference Pixel Streaming web player](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Frontend/implementations/typescript) for an example of how to build a Pixel Streaming web application, with custom UI, on top of this library.
 
 ### Key features
 - Create a WebSocket connection to communicate with the signalling server.

--- a/Frontend/library/src/VideoPlayer/StreamController.ts
+++ b/Frontend/library/src/VideoPlayer/StreamController.ts
@@ -26,7 +26,7 @@ export class StreamController {
     handleOnTrack(rtcTrackEvent: RTCTrackEvent) {
         Logger.Info('handleOnTrack ' + JSON.stringify(rtcTrackEvent.streams));
         // Do not add the track if the ID is `probator` as this is special track created by mediasoup for bitrate probing.
-        // Refer to https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/86 for more details.
+        // Refer to https://github.com/EpicGames/PixelStreamingInfrastructure/pull/86 for more details.
         if (rtcTrackEvent.streams.length < 1 || rtcTrackEvent.streams[0].id === 'probator') {
             return;
         }

--- a/Frontend/ui-library/package.json
+++ b/Frontend/ui-library/package.json
@@ -34,7 +34,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure"
+        "url": "https://github.com/EpicGames/PixelStreamingInfrastructure"
     },
     "author": "Epic Games",
     "license": "MIT",

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -205,7 +205,7 @@ export class Application {
 
         // Additionally iPad on non-Safari browsers doesn't really allow touch inputs and fullscreen video at the same time.
         // If you do this the video gets dragged off back to normal non-fullscreen video and then the video is paused.
-        // See: https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues/219
+        // See: https://github.com/EpicGames/PixelStreamingInfrastructure/issues/219
         const disableFullscreenButton = isIphone || (!isSafari && isIpad);
 
         if (this._options.fullScreenControlsConfig === undefined && disableFullscreenButton) {

--- a/Matchmaker/README.md
+++ b/Matchmaker/README.md
@@ -2,4 +2,4 @@
 The matchmaker has been removed. It was not a good refernce for how to handle Pixel Streaming at scale and was adding to maintenance work, so we made the decision to remove it and discontinue its support.
 
 ### What if I still need Matchmaker?
-You can still obtain it from older revisions of this repo. It is removed for UE5.5, but any previous version of the Infrastructure repo will still have it, latest one being [UE 5.4 matchmaker](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/UE5.4/Matchmaker).
+You can still obtain it from older revisions of this repo. It is removed for UE5.5, but any previous version of the Infrastructure repo will still have it, latest one being [UE 5.4 matchmaker](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/UE5.4/Matchmaker).

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ We have created a [migration guide](/Docs/pixel-streaming-2-migration-guide.md) 
 
 | Health Checks | UE5.8 | UE5.7 | UE5.6 |
 | - | - | - | - |
-| [![Libraries](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-libraries.yml/badge.svg?branch=master)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-libraries.yml) | [![Publish NPM libraries](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml/badge.svg?branch=UE5.8)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) | [![Publish NPM libraries](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml/badge.svg?branch=UE5.7)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) | [![Publish NPM libraries](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml/badge.svg?branch=UE5.6)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) |
-| [![Platform Scripts](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-platform-scripts.yml/badge.svg?branch=master)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-platform-scripts.yml) | [![Publish container images](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml/badge.svg?branch=UE5.8)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml) | [![Publish container images](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml/badge.svg?branch=UE5.7)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml) | [![Publish container images](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml/badge.svg?branch=UE5.6)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml) |
-| [![Signalling Protocol](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-signalling-protocol.yml/badge.svg?branch=master)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-signalling-protocol.yml) | [![Releases](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml/badge.svg?branch=UE5.8)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) | [![Releases](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml/badge.svg?branch=UE5.7)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) | [![Releases](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml/badge.svg?branch=UE5.6)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) |
-| [![Signalling Server Image](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-wilbur.yml/badge.svg?branch=master)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-wilbur.yml) | | | |
-| [![SFU Docker Image](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-sfu.yml/badge.svg?branch=master)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-sfu.yml) | | | |
-| [![Documentation Links](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-markdown-links.yml/badge.svg?branch=master)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/healthcheck-markdown-links.yml) | | | |
+| [![Libraries](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-libraries.yml/badge.svg?branch=master)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-libraries.yml) | [![Publish NPM libraries](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml/badge.svg?branch=UE5.8)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) | [![Publish NPM libraries](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml/badge.svg?branch=UE5.7)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) | [![Publish NPM libraries](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml/badge.svg?branch=UE5.6)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) |
+| [![Platform Scripts](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-platform-scripts.yml/badge.svg?branch=master)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-platform-scripts.yml) | [![Publish container images](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml/badge.svg?branch=UE5.8)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml) | [![Publish container images](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml/badge.svg?branch=UE5.7)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml) | [![Publish container images](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml/badge.svg?branch=UE5.6)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/publish-container-images.yml) |
+| [![Signalling Protocol](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-signalling-protocol.yml/badge.svg?branch=master)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-signalling-protocol.yml) | [![Releases](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml/badge.svg?branch=UE5.8)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) | [![Releases](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml/badge.svg?branch=UE5.7)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) | [![Releases](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml/badge.svg?branch=UE5.6)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) |
+| [![Signalling Server Image](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-wilbur.yml/badge.svg?branch=master)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-wilbur.yml) | | | |
+| [![SFU Docker Image](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-sfu.yml/badge.svg?branch=master)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-image-sfu.yml) | | | |
+| [![Documentation Links](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-markdown-links.yml/badge.svg?branch=master)](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/healthcheck-markdown-links.yml) | | | |
 
 # The official home for the Pixel Streaming servers and frontend!
 The frontend and web server elements for Unreal Pixel Streaming (previously located in `Samples/PixelStreaming/WebServers`) are now in this repository, for all to contribute to. They are referred to as the **Pixel Streaming Infrastructure**.
@@ -113,7 +113,7 @@ npm i @epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.8
 
 ### Tagged source releases + built typescript frontend
 
-[Github releases](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases)
+[Github releases](https://github.com/EpicGames/PixelStreamingInfrastructure/releases)
 
 ## Versions
 
@@ -121,22 +121,22 @@ We maintain versions of the servers and frontend that are compatible with existi
 
 :warning: **There are breaking changes between UE versions - so make sure you get the right version**. :warning:
 
-<ins>For a list of major changes between versions please refer to the [changelog](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/CHANGELOG.md).</ins>
+<ins>For a list of major changes between versions please refer to the [changelog](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/CHANGELOG.md).</ins>
 
 This repository contains the following in branches that track Unreal Engine versions:
 
 | Branch | Status |
 |--------|--------|
-|[Master](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master)| Dev |
-|[UE5.8](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/UE5.8)| Current |
-|[UE5.7](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/UE5.7)| Supported |
-|[UE5.6](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/UE5.6)| End of life |
-|[UE5.5](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/UE5.5)| Unsupported |
+|[Master](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master)| Dev |
+|[UE5.8](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/UE5.8)| Current |
+|[UE5.7](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/UE5.7)| Supported |
+|[UE5.6](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/UE5.6)| End of life |
+|[UE5.5](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/UE5.5)| Unsupported |
 
 | Legend | Meaning |
 |---------|-----------|
 | Dev | This is our dev branch, intended to be paired with [ue5-main](https://github.com/EpicGames/UnrealEngine/tree/ue5-main) - experimental. |
-|Pre-release| Code in here will be paired with the next UE release, we periodically update this branch from `master`. |
+| Pre-release | Code in here will be paired with the next UE release, we periodically update this branch from `master`. |
 | Current | Supported and this is the branch tracking the **latest released** version of UE. |
 | Supported | We will accept bugfixes/issues for this version. |
 | End of life | Once the next UE version is released we will not support this version anymore. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ These releases are mostly handled by the changesets tooling.
 If there is an existing Update CHANGELOG PR for the release branch you are targeting then do the following:
 
 1. Merging this PR into the release branch will consume change sets, update versions and changelogs.
-2. When a package.json file is pushed the [publish action](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) will start scanning packages in the repo.
+2. When a package.json file is pushed the [publish action](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) will start scanning packages in the repo.
 3. If a public package is found to have a greater version number than what is published, the new version will be published.
 4. A tag for the release will be made and a Github release with archives will be created.
 
@@ -21,7 +21,7 @@ If there is no PR for the release then no changesets have been added. If you sti
 1. Make changes to the package.json files of the packages you require publishing.
 2. Make sure the version numbers are increased appropriately.
 3. Push these changes to the release branch.
-4. This will kick off the [publish action](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) and publish as described in the previous steps.
+4. This will kick off the [publish action](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/changesets-publish-npm-packages.yml) and publish as described in the previous steps.
 
 ### Note about release order
 
@@ -30,14 +30,14 @@ The order of publishing packages comes from the order of packages listed in the 
 ## Signalling Server Container
 1. Switch to the target branch (e.g 5.5)
 2. Make/merge any changes into `/SignallingWebServer` directory
-3. This will automatically kick off a [this action](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/container-images.yml) for a build+push of the signalling server container image.
+3. This will automatically kick off a [this action](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/container-images.yml) for a build+push of the signalling server container image.
 
 ## The Github releases archives
 1. Switch to the target branch (e.g 5.5)
 2. Make/merge any changes anywhere in the repo.
-3. Based on the changes made, bump the version number according to [semver](https://semver.org/) in the [`RELEASE_VERSION`](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/RELEASE_VERSION) file.
+3. Based on the changes made, bump the version number according to [semver](https://semver.org/) in the [`RELEASE_VERSION`](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/RELEASE_VERSION) file.
 4. Commit the changes to `RELEASE_VERSION` file.
-6. This will automatically kick off a [this action](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) for tagged Github release with .zip and .tar.gz archives.
+6. This will automatically kick off a [this action](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/workflows/create-gh-release.yml) for tagged Github release with .zip and .tar.gz archives.
 
 ## Handling multiple changes
 If multiple changes have been made, the order of releases should usually be like so:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ These versions are currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-If you find a vulnerability please open an advisory here: https://github.com/EpicGamesExt/PixelStreamingInfrastructure/security/advisories/new
+If you find a vulnerability please open an advisory here: https://github.com/EpicGames/PixelStreamingInfrastructure/security/advisories/new

--- a/Signalling/README.md
+++ b/Signalling/README.md
@@ -14,7 +14,7 @@ npm run build
 
 This will result in a `/dist` output directory.
 
-**Note:** If you just want to get a signalling server up and running refer to ["Getting Started"](https://github.com/EpicGamesExt/PixelStreamingInfrastructure?tab=readme-ov-file#getting-started).
+**Note:** If you just want to get a signalling server up and running refer to ["Getting Started"](https://github.com/EpicGames/PixelStreamingInfrastructure?tab=readme-ov-file#getting-started).
 
 ### NPM package contents
 - ES6 module
@@ -24,9 +24,9 @@ This will result in a `/dist` output directory.
 
 ## Documentation
 
-- [Protocol Notes](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Common/docs/Protocol.md)
-- [Protocol Messages](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/blob/master/Common/docs/messages.md)
+- [Protocol Notes](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Common/docs/Protocol.md)
+- [Protocol Messages](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/Common/docs/messages.md)
 
-The API documentation is [here](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/tree/master/Signalling/docs) and covers details of all exported components of the library.
+The API documentation is [here](https://github.com/EpicGames/PixelStreamingInfrastructure/tree/master/Signalling/docs) and covers details of all exported components of the library.
 
 

--- a/Signalling/package.json
+++ b/Signalling/package.json
@@ -53,6 +53,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure"
+        "url": "https://github.com/EpicGames/PixelStreamingInfrastructure"
     }
 }

--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -257,9 +257,9 @@ function setup_coturn() {
             echo 'CoTURN directory not found...beginning CoTURN download for Mac.'
             coturn_url=""
             if [[ $arch == x86_64* ]]; then
-                coturn_url="https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases/download/v4.6.2-coturn-mac-x86_64/turnserver.zip"
+                coturn_url="https://github.com/EpicGames/PixelStreamingInfrastructure/releases/download/v4.6.2-coturn-mac-x86_64/turnserver.zip"
             elif  [[ $arch == arm* ]]; then
-                coturn_url="https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases/download/v4.6.2-coturn-mac-arm64/turnserver.zip"
+                coturn_url="https://github.com/EpicGames/PixelStreamingInfrastructure/releases/download/v4.6.2-coturn-mac-arm64/turnserver.zip"
             fi
             curl -L -o ./turnserver.zip "$coturn_url"
             mkdir "${SCRIPT_DIR}/coturn" 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -252,7 +252,7 @@ if exist coturn\ (
   echo CoTURN directory not found...beginning CoTURN download for Windows.
 
   @Rem Download nodejs and follow redirects.
-  curl -L -o ./turnserver.zip "https://github.com/EpicGamesExt/PixelStreamingInfrastructure/releases/download/v4.5.2-coturn-windows/turnserver.zip"
+  curl -L -o ./turnserver.zip "https://github.com/EpicGames/PixelStreamingInfrastructure/releases/download/v4.5.2-coturn-windows/turnserver.zip"
 
   @Rem Unarchive the .zip to a directory called "turnserver"
   mkdir coturn & %TAR% -xf turnserver.zip -C coturn


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.8`:
 - [chore: update org references from EpicGamesExt to EpicGames (#901)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/901)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)