### PR TITLE
[UE5.8] chore(deps-dev): bump webpack-dev-server (#908)

### DIFF
--- a/Extras/JSStreamer/package.json
+++ b/Extras/JSStreamer/package.json
@@ -33,7 +33,7 @@
         "typescript-eslint": "8.57.2",
         "webpack": "^5.97.1",
         "webpack-cli": "^6.0.1",
-        "webpack-dev-server": "^5.2.3",
+        "webpack-dev-server": "^5.2.5",
         "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
                 "typescript-eslint": "8.57.2",
                 "webpack": "^5.97.1",
                 "webpack-cli": "^6.0.1",
-                "webpack-dev-server": "^5.2.3",
+                "webpack-dev-server": "^5.2.5",
                 "webpack-node-externals": "^3.0.0"
             }
         },
@@ -17542,9 +17542,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-            "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+            "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.8`:
 - [chore(deps-dev): bump webpack-dev-server (#908)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/908)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)