### PR TITLE
Gate emitUIInteraction on data-channel readiness instead of video

### DIFF
--- a/.changeset/uiinteraction-datachannel-gate.md
+++ b/.changeset/uiinteraction-datachannel-gate.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/lib-pixelstreamingfrontend-ue5.7': patch
+---
+
+Gate `PixelStreaming.emitUIInteraction` on data-channel readiness instead of video readiness. A UIInteraction is sent over the reliable data channel, which opens before the video is decode-ready, so the previous `isVideoReady()` guard could silently drop early interactions on slow connections. Adds a public `WebRtcPlayerController.isDataChannelOpen()` helper.

--- a/.changeset/uiinteraction-datachannel-gate.md
+++ b/.changeset/uiinteraction-datachannel-gate.md
@@ -2,4 +2,4 @@
 '@epicgames-ps/lib-pixelstreamingfrontend-ue5.7': patch
 ---
 
-Gate `PixelStreaming.emitUIInteraction` on data-channel readiness instead of video readiness. A UIInteraction is sent over the reliable data channel, which opens before the video is decode-ready, so the previous `isVideoReady()` guard could silently drop early interactions on slow connections. Adds a public `WebRtcPlayerController.isDataChannelOpen()` helper.
+Gate the input/command methods on data-channel readiness instead of video readiness. A UIInteraction (and the other commands) is sent over the reliable data channel, which opens before the video is decode-ready, so the previous `isVideoReady()` guard could silently drop early messages on slow connections. This now covers `emitUIInteraction`, `emitCommand`, `emitConsoleCommand`, `sendTextboxEntry`, `requestShowFps`, and `requestDataChannelLatencyTest`; `requestLatencyTest` and `requestIframe` keep the video guard because they genuinely depend on the video stream. Adds a public `WebRtcPlayerController.isDataChannelOpen()` helper.

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -741,7 +741,7 @@ export class PixelStreaming {
      * NOTE: There are plans to refactor all request* functions. Expect changes if you use this!
      */
     public requestDataChannelLatencyTest(config: DataChannelLatencyTestConfig) {
-        if (!this._webRtcController.videoPlayer.isVideoReady()) {
+        if (!this._webRtcController.isDataChannelOpen()) {
             return false;
         }
         if (!this._dataChannelLatencyTestController) {
@@ -764,7 +764,7 @@ export class PixelStreaming {
      * @returns
      */
     public requestShowFps() {
-        if (!this._webRtcController.videoPlayer.isVideoReady()) {
+        if (!this._webRtcController.isDataChannelOpen()) {
             return false;
         }
         this._webRtcController.sendShowFps();
@@ -807,7 +807,7 @@ export class PixelStreaming {
      * @returns true if succeeded, false if rejected
      */
     public emitCommand(descriptor: object) {
-        if (!this._webRtcController.videoPlayer.isVideoReady()) {
+        if (!this._webRtcController.isDataChannelOpen()) {
             return false;
         }
         if (!this.allowConsoleCommands && 'ConsoleCommand' in descriptor) {
@@ -823,7 +823,7 @@ export class PixelStreaming {
      * @returns true if succeeded, false if rejected
      */
     public emitConsoleCommand(command: string) {
-        if (!this.allowConsoleCommands || !this._webRtcController.videoPlayer.isVideoReady()) {
+        if (!this.allowConsoleCommands || !this._webRtcController.isDataChannelOpen()) {
             return false;
         }
         this._webRtcController.emitConsoleCommand(command);
@@ -836,7 +836,7 @@ export class PixelStreaming {
      * @returns True if the message could be sent.
      */
     public sendTextboxEntry(contents: string): boolean {
-        if (!this._webRtcController.videoPlayer.isVideoReady()) {
+        if (!this._webRtcController.isDataChannelOpen()) {
             return false;
         }
         this._webRtcController.sendTextboxEntry(contents);

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -790,7 +790,11 @@ export class PixelStreaming {
      * @returns true if succeeded, false if rejected
      */
     public emitUIInteraction(descriptor: object | string) {
-        if (!this._webRtcController.videoPlayer.isVideoReady()) {
+        // A UIInteraction only needs the (reliable, ordered) data channel, which opens before
+        // the video is decode-ready. Gating on isVideoReady() instead would silently drop early
+        // interactions until the first video frame arrives - a problem on slow links where the
+        // application may be waiting on this message before it starts streaming video.
+        if (!this._webRtcController.isDataChannelOpen()) {
             return false;
         }
         this._webRtcController.emitUIInteraction(descriptor);

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1810,6 +1810,14 @@ export class WebRtcPlayerController {
     }
 
     /**
+     * Checks whether the to-streamer (send) data channel is open and ready to send.
+     * @returns true if the data channel exists and its readyState is 'open'.
+     */
+    isDataChannelOpen(): boolean {
+        return this.sendrecvDataChannelController?.dataChannel?.readyState === 'open';
+    }
+
+    /**
      * Send a UIInteraction message
      */
     emitUIInteraction(descriptor: object | string) {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
`PixelStreaming.emitUIInteraction()` only sends the message if `isVideoReady()` returns true, i.e. once the video element has started decoding frames. But a UIInteraction travels over the reliable, ordered data channel, which opens several seconds before the first video frame arrives. So on a slow or high-latency connection, any UIInteraction sent in that early window is silently dropped (the method just returns `false`).

This bit us when the application uses an early UIInteraction to receive setup parameters from the page before it starts streaming video. The interaction was sent while the data channel was already open but the video wasn't ready yet, so it never reached the streamer, and the app fell back to its defaults. It's intermittent because it only happens when video init loses the race.

The same wrong guard applies to the other methods that send over the data channel, not the video track, so they have the same latent problem.

## Solution
Gate the data-channel methods on the data channel being open rather than on the video being ready, since the data channel is what these messages actually use. I added a small public helper `WebRtcPlayerController.isDataChannelOpen()` (returns true when the to-streamer send channel's `readyState === 'open'`) and switched the guard to use it in the methods that transmit over the data channel:

- `emitUIInteraction`
- `emitCommand`
- `emitConsoleCommand` (still also gated on `allowConsoleCommands`)
- `sendTextboxEntry`
- `requestShowFps`
- `requestDataChannelLatencyTest`

`requestLatencyTest` and `requestIframe` keep the `isVideoReady()` guard, because they genuinely depend on the video stream.

## Documentation
The new `isDataChannelOpen()` method has a doc comment, and the reasoning is in a comment on the changed `emitUIInteraction` guard. No public API was removed and the normal case is unchanged — this only stops early data-channel messages from being dropped.

## Test Plan and Compatibility
`npm run build` and `npm run lint` pass for `Frontend/library`. I've been running this change in our own deployment for a while: opening with per-session parameters and reconnecting repeatedly, the parameters now arrive on every connect, including on a slow headless instance where it previously failed roughly one connect in five. Behaviour is identical once video is ready, so existing callers are unaffected.