### PR TITLE
ci: make document link checker manual-only

### DIFF
--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -1,13 +1,11 @@
 name: Check health of document links
 
 on:
+  # Manual-only. The automatic pull_request/push triggers were removed: the
+  # checker fails the whole job on any single flaky external link (e.g. a CDN
+  # returning 4xx to CI runners), which created noise and blocked PRs for little
+  # benefit. Run it on demand from the Actions tab when a link sweep is wanted.
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "**.md" # Trigger only when md files are in a PR
-  push:
-    paths:
-      - '**.md'  # Trigger only when md files are pushed
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Stops the markdown **document link checker** from running automatically. The `pull_request` and `push` (`**.md`) triggers are removed; only `workflow_dispatch` remains, so it can still be run on demand from the Actions tab.

## Why

The checker fails the entire job on **any single flaky external link** — e.g. `webrtchacks.com/sdp-anatomy/` (linked from `Common/docs/Protocol.md`) returns `200` for normal clients but a Cloudflare bot-filter `4xx` to GitHub Actions runner IPs. That repeatedly blocked unrelated PRs and opened "Link Checker Report" issues, for little benefit relative to the noise.

## Behaviour

- No longer runs on PRs or pushes — no flaky failures, no PR blocking, no auto-generated issues.
- Still runnable manually via `workflow_dispatch`; the repository guard and issue create/close steps are unchanged.
- Re-enabling later is just re-adding the two triggers (a comment in the file notes this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)