### PR TITLE
ci: use AUTOMATION_PAT for workflows that open PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,13 +23,12 @@ jobs:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.5.1
         with:
-          # Prefer a PAT when configured. PRs opened with the default
-          # GITHUB_TOKEN don't trigger downstream `pull_request` workflows
-          # (anti-recursion limit), which means CI does not run on backport
-          # PRs. Configure a repo or org secret named BACKPORT_PAT
-          # (PAT with `repo` scope) to fix that. Falls back to GITHUB_TOKEN
-          # if the secret is not set, preserving the prior behavior.
-          github_token: ${{ secrets.BACKPORT_PAT || secrets.GITHUB_TOKEN }}
+          # A PAT (repo + workflow scope) is required: org policy forbids the
+          # default GITHUB_TOKEN from creating PRs, and PRs opened with it also
+          # don't trigger downstream `pull_request` workflows (anti-recursion
+          # limit), so CI would not run on backport PRs. Configure a repo or
+          # org secret named AUTOMATION_PAT.
+          github_token: ${{ secrets.AUTOMATION_PAT }}
           auto_backport_label_prefix: auto-backport-to-
           add_original_reviewers: true
 

--- a/.github/workflows/changesets-prune-master.yml
+++ b/.github/workflows/changesets-prune-master.yml
@@ -44,7 +44,9 @@ jobs:
         if: steps.prune.outputs.removed_count != '0'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Org policy forbids the default GITHUB_TOKEN from creating PRs, so a
+          # PAT (repo + workflow scope) is required here.
+          token: ${{ secrets.AUTOMATION_PAT }}
           base: master
           branch: automated/prune-changesets
           delete-branch: true

--- a/.github/workflows/changesets-update-changelogs.yml
+++ b/.github/workflows/changesets-update-changelogs.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1.4.10
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Org policy forbids the default GITHUB_TOKEN from creating PRs, so a
+          # PAT (repo + workflow scope) is required to open the release PR.
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
         with:
           title: '[Bot] NPM Packages Release ${{ github.ref_name }}'
           commit: 'Updated NPM changelogs'


### PR DESCRIPTION
## Summary

The org-level policy **"Allow GitHub Actions to create and approve pull requests"** is disabled, so the default `GITHUB_TOKEN` cannot open PRs. This is what broke the **Prune Master Changesets** job, which failed with:

> `GitHub Actions is not permitted to create or approve pull requests.`

This points the three workflows that open PRs at a single repo/org secret, `AUTOMATION_PAT` (a PAT with `repo` + `workflow` scope), instead of `GITHUB_TOKEN`:

- `changesets-prune-master.yml` — the job that actually failed (`peter-evans/create-pull-request`)
- `changesets-update-changelogs.yml` — the release PR (`changesets/action`); same policy, would fail on the next release
- `backport.yml` — replaces the previous `BACKPORT_PAT` with the unified `AUTOMATION_PAT`

### Why drop the `GITHUB_TOKEN` fallbacks?

Under this org policy the fallback can only ever fail, and it produces the misleading *"not permitted to create or approve pull requests"* error. Referencing `AUTOMATION_PAT` directly means a missing/expired secret fails loudly and clearly instead.

`healthcheck-markdown-links.yml` is intentionally left unchanged — it creates *issues*, which `GITHUB_TOKEN` is still permitted to do.

## Notes

- Requires the `AUTOMATION_PAT` secret on the EpicGames repo/org (already added), with `repo` + `workflow` scope and SSO-authorized for the org.
- The old `BACKPORT_PAT` secret is now unused and can be removed.