### PR TITLE
[UE5.6] ci: use AUTOMATION_PAT for workflows that open PRs (#914)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,13 +23,12 @@ jobs:
       - name: Backport Action
         uses: sqren/backport-github-action@v8.9.3
         with:
-          # Prefer a PAT when configured. PRs opened with the default
-          # GITHUB_TOKEN don't trigger downstream `pull_request` workflows
-          # (anti-recursion limit), which means CI does not run on backport
-          # PRs. Configure a repo or org secret named BACKPORT_PAT
-          # (PAT with `repo` scope) to fix that. Falls back to GITHUB_TOKEN
-          # if the secret is not set, preserving the prior behavior.
-          github_token: ${{ secrets.BACKPORT_PAT || secrets.GITHUB_TOKEN }}
+          # A PAT (repo + workflow scope) is required: org policy forbids the
+          # default GITHUB_TOKEN from creating PRs, and PRs opened with it also
+          # don't trigger downstream `pull_request` workflows (anti-recursion
+          # limit), so CI would not run on backport PRs. Configure a repo or
+          # org secret named AUTOMATION_PAT.
+          github_token: ${{ secrets.AUTOMATION_PAT }}
           auto_backport_label_prefix: auto-backport-to-
           add_original_reviewers: true
 

--- a/.github/workflows/changesets-update-changelogs.yml
+++ b/.github/workflows/changesets-update-changelogs.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1.4.10
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Org policy forbids the default GITHUB_TOKEN from creating PRs, so a
+          # PAT (repo + workflow scope) is required to open the release PR.
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
         with:
           title: '[Bot] NPM Packages Release ${{ github.ref_name }}'
           commit: 'Updated NPM changelogs'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.6`:
 - [ci: use AUTOMATION_PAT for workflows that open PRs (#914)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/914)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)