### PR TITLE
chore: prune changesets from master

### DIFF
--- a/.changeset/server-player-keepalive.md
+++ b/.changeset/server-player-keepalive.md
@@ -1,6 +1,0 @@
----
-'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': patch
-'@epicgames-ps/wilbur': patch
----
-
-Add an optional server-side keepalive that disconnects players whose connection has died without a clean close. Previously `KeepaliveMonitor` was only used on the client, so a player whose socket dropped silently (sleeping laptop, lost Wi-Fi, killed tab) stayed subscribed until the OS TCP keepalive reaped it, which could hold a `maxSubscribers` slot in the meantime. The new `IServerConfig.playerKeepaliveTimeout` controls this; the signalling server exposes it as `--player_keepalive_timeout <milliseconds>` (default 30000, 0 disables).


### PR DESCRIPTION
Automated cleanup. master never consumes changesets; release branches receive them via cherry-pick of the introducing commit, so these working-tree copies are redundant and safe to remove.

## Removed changesets
- `server-player-keepalive.md`
