### PR TITLE
chore: prune changesets from master

### DIFF
--- a/.changeset/uiinteraction-datachannel-gate.md
+++ b/.changeset/uiinteraction-datachannel-gate.md
@@ -1,5 +1,0 @@
----
-'@epicgames-ps/lib-pixelstreamingfrontend-ue5.7': patch
----
-
-Gate the input/command methods on data-channel readiness instead of video readiness. A UIInteraction (and the other commands) is sent over the reliable data channel, which opens before the video is decode-ready, so the previous `isVideoReady()` guard could silently drop early messages on slow connections. This now covers `emitUIInteraction`, `emitCommand`, `emitConsoleCommand`, `sendTextboxEntry`, `requestShowFps`, and `requestDataChannelLatencyTest`; `requestLatencyTest` and `requestIframe` keep the video guard because they genuinely depend on the video stream. Adds a public `WebRtcPlayerController.isDataChannelOpen()` helper.


### PR DESCRIPTION
Automated cleanup. master never consumes changesets; release branches receive them via cherry-pick of the introducing commit, so these working-tree copies are redundant and safe to remove.

## Removed changesets
- `uiinteraction-datachannel-gate.md`
