### PR TITLE
Only route player signalling messages to subscribed players

### DIFF
--- a/.changeset/streamer-subscriber-isolation.md
+++ b/.changeset/streamer-subscriber-isolation.md
@@ -1,0 +1,6 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': patch
+'@epicgames-ps/wilbur': patch
+---
+
+Enforce streamer/player subscription when routing signalling messages. Previously `StreamerConnection.forwardMessage`, `StreamerConnection.onDisconnectPlayerRequest` and `SFUConnection.sendToPlayer` resolved their target via the global player registry without checking that the player was subscribed to the sending streamer/SFU. On a signalling server shared by multiple streamers this let one streamer send forged `offer`/`answer`/`iceCandidate` messages to, or disconnect, players belonging to another streamer. These paths now drop messages for players that are not in the streamer's `subscribers` set. SFU connections now register themselves as a subscriber of their upstream streamer so messages destined for the SFU continue to be forwarded.

--- a/Signalling/src/SFUConnection.ts
+++ b/Signalling/src/SFUConnection.ts
@@ -180,6 +180,9 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         }
 
         this.subscribedStreamer = streamer;
+        // Register as a subscriber of the upstream streamer so it will forward signalling messages
+        // back to this SFU (the streamer's forwardMessage only sends to subscribed players).
+        this.subscribedStreamer.subscribers.add(this.playerId);
         this.subscribedStreamer.on('layer_preference', this.layerPreferenceListener);
         this.subscribedStreamer.on('id_changed', this.streamerIdChangeListener);
         this.subscribedStreamer.on('disconnect', this.streamerDisconnectedListener);
@@ -202,6 +205,7 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         });
         this.sendToStreamer(disconnectedMessage);
 
+        this.subscribedStreamer.subscribers.delete(this.playerId);
         this.subscribedStreamer.off('layer_preference', this.layerPreferenceListener);
         this.subscribedStreamer.off('id_changed', this.streamerIdChangeListener);
         this.subscribedStreamer.off('disconnect', this.streamerDisconnectedListener);
@@ -229,6 +233,14 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         if (!message.playerId) {
             Logger.error(
                 `SFU ${this.streamerId} trying to send a message to a player with no playerId. Ignored.`
+            );
+            return;
+        }
+        if (!this.subscribers.has(message.playerId)) {
+            // Only send to players subscribed to this SFU, otherwise the SFU could target any player
+            // on the server via the global player registry (cross-tenant signalling).
+            Logger.error(
+                `SFU ${this.streamerId} tried to send a message to player ${message.playerId} which is not subscribed to it. Ignored.`
             );
             return;
         }

--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -133,6 +133,13 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
     private forwardMessage(message: BaseMessage): void {
         if (!message.playerId) {
             Logger.warn(`No playerId specified, cannot forward message: ${stringify(message)}`);
+        } else if (!this.subscribers.has(message.playerId)) {
+            // Only forward to players that are actually subscribed to this streamer. Without this
+            // check a streamer could target any player on the server (resolved via the global player
+            // registry), allowing cross-tenant signalling on a shared signalling server.
+            Logger.warn(
+                `Streamer ${this.streamerId} tried to forward a message to player ${message.playerId} which is not subscribed to it. Ignoring.`
+            );
         } else {
             const player = this.server.playerRegistry.get(message.playerId);
             if (player) {
@@ -157,6 +164,14 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
 
     private onDisconnectPlayerRequest(message: Messages.disconnectPlayer): void {
         if (message.playerId) {
+            if (!this.subscribers.has(message.playerId)) {
+                // A streamer may only disconnect its own subscribed players. Otherwise any streamer
+                // could forcibly close arbitrary player connections on a shared signalling server.
+                Logger.warn(
+                    `Streamer ${this.streamerId} tried to disconnect player ${message.playerId} which is not subscribed to it. Ignoring.`
+                );
+                return;
+            }
             const player = this.server.playerRegistry.get(message.playerId);
             if (player) {
                 player.protocol.disconnect(1011, message.reason);


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [x] SFU

## Problem statement:
When routing WebRTC signalling messages, `StreamerConnection` (offer/answer/iceCandidate forwarding and `disconnectPlayer`) and `SFUConnection` resolved the target player from the global player registry via `playerRegistry.get(message.playerId)` without checking that the player was subscribed to the sending streamer/SFU. As a result a streamer/SFU could send messages to, or disconnect, players it is not actually serving.

## Solution
Gate these paths on the streamer's existing `subscribers` set so only subscribed players are targeted:

- `StreamerConnection.forwardMessage` and `onDisconnectPlayerRequest` now ignore (and log a warning for) a `playerId` that is not in `this.subscribers`.
- `SFUConnection.sendToPlayer` gets the same check.
- `SFUConnection` now registers/deregisters itself in its upstream streamer's `subscribers` set on `subscribe`/`unsubscribe`. The SFU connects to a streamer as a player but previously never registered there, so this is required to keep legitimate SFU-bound messages flowing under the new check.

A changeset is included (`patch` for `lib-pixelstreamingsignalling-ue5.7` and `wilbur`).

## Documentation
No public API change. Behavioural change only: signalling messages and disconnect requests are now ignored (with a warning log) when the target player is not subscribed to the sender.

## Test Plan and Compatibility
- `npm run build` (CJS + ESM) and `npm run lint` pass for the Signalling package.
- Verified with a local harness that stands up a real `SignallingServer`: a player subscribes to one streamer, and a second streamer is confirmed to no longer reach that player while the owning streamer still can. Also confirmed the SFU relay path still forwards messages correctly after the subscriber-registration change (the change was made specifically to preserve it).