### PR TITLE
chore: prune changesets from master

### DIFF
--- a/.changeset/streamer-id-authorizer-hook.md
+++ b/.changeset/streamer-id-authorizer-hook.md
@@ -1,5 +1,0 @@
----
-'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': minor
----
-
-Add extension points so consumers can plug in their own authentication and authorization without the library shipping an auth scheme. Connections now expose the HTTP upgrade `request` (`IStreamer.request` / `IPlayer.request`) so identity attached during a `verifyClient` check survives to later decisions, and `IServerConfig.authorizeStreamerId` lets a consumer authorize, override (e.g. namespace per tenant), or reject the id a streamer registers as — the seam for preventing streamer-id squatting. Default behaviour is unchanged when these are not supplied. See `Docs/Security-Guidelines.md`.

--- a/.changeset/streamer-subscriber-isolation.md
+++ b/.changeset/streamer-subscriber-isolation.md
@@ -1,6 +1,0 @@
----
-'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': patch
-'@epicgames-ps/wilbur': patch
----
-
-Enforce streamer/player subscription when routing signalling messages. Previously `StreamerConnection.forwardMessage`, `StreamerConnection.onDisconnectPlayerRequest` and `SFUConnection.sendToPlayer` resolved their target via the global player registry without checking that the player was subscribed to the sending streamer/SFU. On a signalling server shared by multiple streamers this let one streamer send forged `offer`/`answer`/`iceCandidate` messages to, or disconnect, players belonging to another streamer. These paths now drop messages for players that are not in the streamer's `subscribers` set. SFU connections now register themselves as a subscriber of their upstream streamer so messages destined for the SFU continue to be forwarded.


### PR DESCRIPTION
Automated cleanup. master never consumes changesets; release branches receive them via cherry-pick of the introducing commit, so these working-tree copies are redundant and safe to remove.

## Removed changesets
- `streamer-id-authorizer-hook.md`
- `streamer-subscriber-isolation.md`
