### PR TITLE
[UE5.5] fix(signalling): only route player messages to subscribed players (#920)

### DIFF
--- a/.changeset/streamer-subscriber-isolation.md
+++ b/.changeset/streamer-subscriber-isolation.md
@@ -1,0 +1,6 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': patch
+'@epicgames-ps/wilbur': patch
+---
+
+Enforce streamer/player subscription when routing signalling messages. Previously `StreamerConnection.forwardMessage`, `StreamerConnection.onDisconnectPlayerRequest` and `SFUConnection.sendToPlayer` resolved their target via the global player registry without checking that the player was subscribed to the sending streamer/SFU. On a signalling server shared by multiple streamers this let one streamer send forged `offer`/`answer`/`iceCandidate` messages to, or disconnect, players belonging to another streamer. These paths now drop messages for players that are not in the streamer's `subscribers` set. SFU connections now register themselves as a subscriber of their upstream streamer so messages destined for the SFU continue to be forwarded.

--- a/Signalling/src/SFUConnection.ts
+++ b/Signalling/src/SFUConnection.ts
@@ -180,6 +180,9 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         }
 
         this.subscribedStreamer = streamer;
+        // Register as a subscriber of the upstream streamer so it will forward signalling messages
+        // back to this SFU (the streamer's forwardMessage only sends to subscribed players).
+        this.subscribedStreamer.subscribers.add(this.playerId);
         this.subscribedStreamer.on('layer_preference', this.layerPreferenceListener);
         this.subscribedStreamer.on('id_changed', this.streamerIdChangeListener);
         this.subscribedStreamer.on('disconnect', this.streamerDisconnectedListener);
@@ -202,6 +205,7 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         });
         this.sendToStreamer(disconnectedMessage);
 
+        this.subscribedStreamer.subscribers.delete(this.playerId);
         this.subscribedStreamer.off('layer_preference', this.layerPreferenceListener);
         this.subscribedStreamer.off('id_changed', this.streamerIdChangeListener);
         this.subscribedStreamer.off('disconnect', this.streamerDisconnectedListener);
@@ -229,6 +233,14 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         if (!message.playerId) {
             Logger.error(
                 `SFU ${this.streamerId} trying to send a message to a player with no playerId. Ignored.`
+            );
+            return;
+        }
+        if (!this.subscribers.has(message.playerId)) {
+            // Only send to players subscribed to this SFU, otherwise the SFU could target any player
+            // on the server via the global player registry (cross-tenant signalling).
+            Logger.error(
+                `SFU ${this.streamerId} tried to send a message to player ${message.playerId} which is not subscribed to it. Ignored.`
             );
             return;
         }

--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -133,6 +133,13 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
     private forwardMessage(message: BaseMessage): void {
         if (!message.playerId) {
             Logger.warn(`No playerId specified, cannot forward message: ${stringify(message)}`);
+        } else if (!this.subscribers.has(message.playerId)) {
+            // Only forward to players that are actually subscribed to this streamer. Without this
+            // check a streamer could target any player on the server (resolved via the global player
+            // registry), allowing cross-tenant signalling on a shared signalling server.
+            Logger.warn(
+                `Streamer ${this.streamerId} tried to forward a message to player ${message.playerId} which is not subscribed to it. Ignoring.`
+            );
         } else {
             const player = this.server.playerRegistry.get(message.playerId);
             if (player) {
@@ -158,6 +165,14 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
 
     private onDisconnectPlayerRequest(message: Messages.disconnectPlayer): void {
         if (message.playerId) {
+            if (!this.subscribers.has(message.playerId)) {
+                // A streamer may only disconnect its own subscribed players. Otherwise any streamer
+                // could forcibly close arbitrary player connections on a shared signalling server.
+                Logger.warn(
+                    `Streamer ${this.streamerId} tried to disconnect player ${message.playerId} which is not subscribed to it. Ignoring.`
+                );
+                return;
+            }
             const player = this.server.playerRegistry.get(message.playerId);
             if (player) {
                 player.protocol.disconnect(1011, message.reason);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [fix(signalling): only route player messages to subscribed players (#920)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/920)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)