### PR TITLE
chore: prune changesets from master

### DIFF
--- a/.changeset/silly-shoes-cut.md
+++ b/.changeset/silly-shoes-cut.md
@@ -1,6 +1,0 @@
----
-'@epicgames-ps/lib-pixelstreamingfrontend-ue5.8': patch
-'@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.8': patch
----
-
-Include generated TypeScript declaration files in the published frontend packages.


### PR DESCRIPTION
Automated cleanup. master never consumes changesets; release branches receive them via cherry-pick of the introducing commit, so these working-tree copies are redundant and safe to remove.

## Removed changesets
- `silly-shoes-cut.md`
