### PR TITLE
[UE5.6] chore(deps): bump ip-address (#948)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9538,9 +9538,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.6`:
 - [chore(deps): bump ip-address (#948)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/948)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)