### PR TITLE
chore(deps): bump js-yaml overrides to 3.15.1 and 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,9 +2249,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11685,9 +11685,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -13397,9 +13397,9 @@
             }
         },
         "node_modules/openapi-framework/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -14473,9 +14473,9 @@
             }
         },
         "node_modules/read-yaml-file/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "fast-uri@^3": "^3.1.5",
         "shell-quote": "^1.10.0",
         "launch-editor": "^2.14.1",
-        "js-yaml@^4": "^4.3.0",
+        "js-yaml@^3": "^3.15.1",
+        "js-yaml@^4": "^4.3.1",
         "@babel/core": "^7.29.6"
     },
     "dependencies": {}


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

Root-level dependency overrides only — no component source code changes. The Signalling server is checked because it is the one component with a **runtime** path to the vulnerable package.

## Problem statement:

Two open Dependabot alerts, both GHSA-5p4m-2wfm-xmqj (high) — quadratic CPU consumption in `js-yaml`'s `!!omap` resolution, a potential DoS on untrusted YAML input:

| Alert | Scope | Path |
|---|---|---|
| #229 | runtime | `package-lock.json` |
| #230 | development | `package-lock.json` |

`package.json` already carried a `"js-yaml@^4": "^4.3.0"` override, but the 4.x fix landed in **4.3.1**, so the pin sat one patch short. The advisory separately covers 3.x via a backport in **3.15.1**, and three transitive copies of 3.15.0 remained in the tree. One of those was runtime-scoped, which is the alert that matters for shipped code:

`SignallingWebServer` → `express-openapi@^12.1.3` → `openapi-framework` → `js-yaml@^3.10.0`

## Solution

Raise the existing 4.x override and add a matching 3.x override, since the two majors are patched by separate releases and a single override key cannot span both:

```diff
- "js-yaml@^4": "^4.3.0",
+ "js-yaml@^3": "^3.15.1",
+ "js-yaml@^4": "^4.3.1",
```

This follows the established pattern in this repo of resolving transitive advisories through root `overrides` (see #952, #943, #884).

### Changes

- `package.json`: bumped `js-yaml@^4` to `^4.3.1`; added `js-yaml@^3` at `^3.15.1`
- `package-lock.json`: all four `js-yaml` entries moved to patched versions — version and integrity lines only, no incidental dependency drift

| Location | Before | After |
|---|---|---|
| `node_modules/js-yaml` | 4.3.0 | 4.3.1 |
| `openapi-framework/node_modules/js-yaml` (runtime) | 3.15.0 | 3.15.1 |
| `@istanbuljs/load-nyc-config/node_modules/js-yaml` | 3.15.0 | 3.15.1 |
| `read-yaml-file/node_modules/js-yaml` | 3.15.0 | 3.15.1 |

No changeset is included, matching the convention of prior `chore(deps)` override commits, which touch only `package.json` and the lockfile.

## Documentation

Not applicable — no functional or API change. Both bumps are upstream patch releases with no behavioural change beyond the advisory fix.

## Test Plan and Compatibility

This change was AI-assisted; below is the full validation chain.

Beyond what CI covers:

- Confirmed both patch versions exist upstream before pinning: `npm view js-yaml versions` lists `3.15.1` and `4.3.1`.
- Found that plain `npm install` re-resolved only one of the three 3.x copies, leaving `openapi-framework` and `@istanbuljs/load-nyc-config` on 3.15.0. `npm update js-yaml` was required to move the rest. Verified the end state by walking every `js-yaml` entry in the lockfile — all four are on patched versions, with zero remaining on 3.15.0 or 4.3.0.
- Audited the other lockfile in the repo, `Extras/eslint/plugin-check-copyright/package-lock.json`, which was already on 4.3.1 and needed no change.
- Reviewed the full lockfile diff to confirm it is scoped to `js-yaml` version and integrity lines. `webpack-dev-server@6.0.0` appears in an `npm install` engine warning but was already present on `master` and is not in this diff.
- `npm audit` no longer reports this advisory.

Verified via CI-equivalent runs locally:

- `npm run build` — succeeded across all workspaces.
- `cd Frontend/library && npm test` — 46/46 tests passed, 5/5 suites.

### Known remaining audit finding (out of scope)

`npm audit` still reports one high for `file-type` (13.0.0–21.3.0, infinite loop on malformed MKV/ASF input), reachable only as a dev dependency through `open-cli`. Dependabot has **not** raised an alert for it, and the only available fix is a semver-major bump of `open-cli` to 9.0.0. Left out of this PR deliberately to keep it to a clean patch-level security bump; worth a separate decision.