### PR TITLE
[UE5.7] chore(deps): bump js-yaml overrides to 3.15.1 and 4.3.1 (#980)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,9 +1064,9 @@
             }
         },
         "node_modules/@changesets/parse/node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -1978,9 +1978,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -11194,9 +11194,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -18074,7 +18074,7 @@
         },
         "Signalling": {
             "name": "@epicgames-ps/lib-pixelstreamingsignalling-ue5.7",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
                 "body-parser": "^1.20.4",
@@ -18115,7 +18115,7 @@
         },
         "SignallingWebServer": {
             "name": "@epicgames-ps/wilbur",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "license": "MIT",
             "dependencies": {
                 "@epicgames-ps/lib-pixelstreamingsignalling-ue5.7": "*",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "fast-uri@^3": "^3.1.4",
         "shell-quote": "^1.10.0",
         "launch-editor": "^2.14.1",
-        "js-yaml@^4": "^4.3.0",
+        "js-yaml@^3": "^3.15.1",
+        "js-yaml@^4": "^4.3.1",
         "@babel/core": "^7.29.6"
     },
     "dependencies": {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [chore(deps): bump js-yaml overrides to 3.15.1 and 4.3.1 (#980)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/980)

Created manually because the automated backport hit a merge conflict.

## Why the automated backport failed

Only **diff context** drifted — no missing functional change. `master` had already bumped neighbouring override pins, so the 3-line context around the `js-yaml` entry did not match:

| Override | master | UE5.7 |
|---|---|---|
| `brace-expansion@^5` | `^5.0.9` | `^5.0.8` |
| `fast-uri@^3` | `^3.1.5` | `^3.1.4` |

The bot therefore suggested backporting #952 (which made those bumps) as a prerequisite. **That is not required** — it is a context mismatch, not a dependency. `package.json` in fact auto-merged cleanly; only `package-lock.json` conflicted.

UE5.7 keeps its own `brace-expansion` and `fast-uri` pins here. This PR is scoped strictly to `js-yaml`; whether to backport #952 is a separate decision.

## Vulnerability on this branch

UE5.7 was affected, including a **runtime**-scoped copy via `SignallingWebServer` → `express-openapi@^12.1.3` → `openapi-framework` → `js-yaml@^3.10.0`:

| Location | Before | After |
|---|---|---|
| `node_modules/js-yaml` (runtime) | 3.15.0 | 3.15.1 |
| `@changesets/parse/node_modules/js-yaml` | 4.3.0 | 4.3.1 |
| `@eslint/eslintrc/node_modules/js-yaml` | 4.3.0 | 4.3.1 |

## Changes

- `package.json`: bumped `js-yaml@^4` to `^4.3.1`, added `js-yaml@^3` at `^3.15.1` — identical to the master change, applied onto UE5.7's own override block
- `package-lock.json`: regenerated; all three `js-yaml` entries now on patched versions

### Note on two unrelated lockfile lines

The diff also syncs two workspace self-version entries:

| Workspace | lockfile before | `package.json` on UE5.7 | lockfile after |
|---|---|---|---|
| `Signalling` | 0.4.0 | **0.5.0** | 0.5.0 |
| `SignallingWebServer` | 3.1.1 | **3.2.0** | 3.2.0 |

This is **pre-existing drift on UE5.7**, not a change introduced here — the committed lockfile was already out of sync with those packages' own `package.json` versions (a release bump that never regenerated the lockfile). Any `npm install` on this branch produces it. I let it stand rather than hand-editing the lockfile back into an inconsistent state.

# Test Plan

- Resolved the conflict by resetting `package-lock.json` to the UE5.7 revision and regenerating it, rather than hand-merging conflict markers.
- `npm install` alone left `js-yaml` at 3.15.0; `npm update js-yaml` was needed to move it. Verified the end state by walking every `js-yaml` entry in the lockfile — none remain on 3.15.0 or 4.3.0.
- Confirmed the resolved override block retains UE5.7's `brace-expansion@^5.0.8` / `fast-uri@^3.1.4` and does **not** pull in `launch-editor` or `@babel/core` from master's block.
- Verified the two non-`js-yaml` lockfile lines are pre-existing drift by diffing `Signalling`/`SignallingWebServer` `package.json` versions against `upstream/UE5.7`'s lockfile.
- `npm run build` — succeeded across all workspaces.
- `cd Frontend/library && npm test` — 42/42 tests passed, 4/4 suites.