### PR TITLE
[UE5.6] chore(deps): bump js-yaml overrides to 3.15.1 and 4.3.1 (#980)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2146,9 +2146,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11172,9 +11172,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -13030,9 +13030,9 @@
             }
         },
         "node_modules/openapi-framework/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -14099,9 +14099,9 @@
             }
         },
         "node_modules/read-yaml-file/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18099,7 +18099,7 @@
         },
         "Signalling": {
             "name": "@epicgames-ps/lib-pixelstreamingsignalling-ue5.6",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "body-parser": "^1.20.4",
@@ -18140,7 +18140,7 @@
         },
         "SignallingWebServer": {
             "name": "@epicgames-ps/wilbur",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
                 "@epicgames-ps/lib-pixelstreamingsignalling-ue5.6": "*",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
         "webpack-dev-server@^5": "^5.2.6",
         "brace-expansion@^5": "^5.0.8",
         "fast-uri@^3": "^3.1.4",
-        "shell-quote": "^1.10.0"
+        "shell-quote": "^1.10.0",
+        "js-yaml@^3": "^3.15.1",
+        "js-yaml@^4": "^4.3.1"
     },
     "dependencies": {}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.6`:
 - [chore(deps): bump js-yaml overrides to 3.15.1 and 4.3.1 (#980)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/980)

Created manually because the automated backport hit a merge conflict.

## Why the automated backport failed

UE5.6's `overrides` block has drifted further from `master` than UE5.7's, so the conflict was larger — but it is still purely **context** drift, not a missing functional change:

| Override | master | UE5.6 |
|---|---|---|
| `webpack-dev-server@^5` | `^5.2.4` | `^5.2.6` (ahead) |
| `brace-expansion@^5` | `^5.0.9` | `^5.0.8` |
| `fast-uri@^3` | `^3.1.5` | `^3.1.4` |
| `launch-editor` | `^2.14.1` | *absent* |
| `@babel/core` | `^7.29.6` | *absent* |
| `js-yaml@^4` | `^4.3.1` | *absent* |

That is why the bot suggested both #952 and #905 as prerequisites. **Neither is required** for this fix. I resolved the conflict by keeping every UE5.6 pin as-is and adding *only* the two `js-yaml` entries — `launch-editor` and `@babel/core` are deliberately **not** introduced here, as they belong to those other PRs. Note UE5.6's `webpack-dev-server` pin is *ahead* of master's, so it was preserved rather than regressed.

Because UE5.6 had no `js-yaml` override at all, both majors are added here rather than one being bumped.

## Vulnerability on this branch

UE5.6 was affected on all four copies, including a **runtime**-scoped one via `SignallingWebServer` → `express-openapi@^12.1.3` → `openapi-framework` → `js-yaml@^3.10.0`:

| Location | Before | After |
|---|---|---|
| `openapi-framework/node_modules/js-yaml` (runtime) | 3.15.0 | 3.15.1 |
| `node_modules/js-yaml` | 4.3.0 | 4.3.1 |
| `@istanbuljs/load-nyc-config/node_modules/js-yaml` | 3.15.0 | 3.15.1 |
| `read-yaml-file/node_modules/js-yaml` | 3.15.0 | 3.15.1 |

## Changes

- `package.json`: added `js-yaml@^3` at `^3.15.1` and `js-yaml@^4` at `^4.3.1` to UE5.6's existing override block, leaving all other pins untouched
- `package-lock.json`: regenerated; all four `js-yaml` entries now on patched versions

### Note on two unrelated lockfile lines

The diff also syncs two workspace self-version entries:

| Workspace | lockfile before | `package.json` on UE5.6 | lockfile after |
|---|---|---|---|
| `Signalling` | 0.2.1 | **0.3.0** | 0.3.0 |
| `SignallingWebServer` | 2.4.1 | **2.5.0** | 2.5.0 |

This is **pre-existing drift on UE5.6** (same situation as the UE5.7 backport, #982), not a change introduced here — the committed lockfile was already out of sync with those packages' own `package.json` versions. Any `npm install` on this branch produces it. `Common` and `SFU` were already in sync and are untouched.

# Test Plan

- Resolved the conflict by hand-merging `package.json` to keep all UE5.6 pins, then resetting `package-lock.json` to the UE5.6 revision and regenerating it rather than trusting the auto-merged lockfile (which had silently taken master's tree).
- Validated the resolved `package.json` parses as JSON and confirmed the final override block keeps `webpack-dev-server@^5.2.6`, `brace-expansion@^5.0.8`, `fast-uri@^3.1.4` and omits `launch-editor` / `@babel/core`.
- `npm install` alone left 3.x copies at 3.15.0; `npm update js-yaml` was needed to move them. Verified by walking every `js-yaml` entry in the lockfile — none remain on 3.15.0 or 4.3.0.
- Verified the two non-`js-yaml` lockfile lines are pre-existing drift by diffing all four workspace `package.json` versions against `upstream/UE5.6`'s lockfile.
- `npm run build` — succeeded across all workspaces.
- `cd Frontend/library && npm test` — 42/42 tests passed, 4/4 suites.