### PR TITLE
fix(sfu): recover after peer and streamer disconnects

### DIFF
--- a/.changeset/sfu-peer-lookup-and-resubscribe.md
+++ b/.changeset/sfu-peer-lookup-and-resubscribe.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/pixelstreaming-sfu': patch
+---
+
+Fix two faults that stopped the SFU serving a stream until it was restarted. `peers` is a `Map`, so `peers.get()` returns `undefined` for an unknown id, but `onPeerDisconnected` and `onLayerPreference` guarded the result with `!== null`, which `undefined` passes: a player that connected while no streamer was present is never added to the map (`onPeerConnected` returns early), so disconnecting it dereferenced `undefined` and crashed the process. Both now use the `if (!peer)` form already used elsewhere in the file. Separately, `onStreamerDisconnected` only scheduled its `listStreamers` retry inside the `streamer !== null` branch, so when the handler ran with `streamer` already null — a duplicate disconnect, or a streamer lost mid-negotiation — the rediscovery poll was never rescheduled and the SFU sat idle indefinitely while still connected to the signalling server, appearing healthy. The retry is now scheduled unconditionally.

--- a/.changeset/sfu-peer-lookup-and-resubscribe.md
+++ b/.changeset/sfu-peer-lookup-and-resubscribe.md
@@ -2,4 +2,14 @@
 '@epicgames-ps/pixelstreaming-sfu': patch
 ---
 
-Fix two faults that stopped the SFU serving a stream until it was restarted. `peers` is a `Map`, so `peers.get()` returns `undefined` for an unknown id, but `onPeerDisconnected` and `onLayerPreference` guarded the result with `!== null`, which `undefined` passes: a player that connected while no streamer was present is never added to the map (`onPeerConnected` returns early), so disconnecting it dereferenced `undefined` and crashed the process. Both now use the `if (!peer)` form already used elsewhere in the file. Separately, `onStreamerDisconnected` only scheduled its `listStreamers` retry inside the `streamer !== null` branch, so when the handler ran with `streamer` already null — a duplicate disconnect, or a streamer lost mid-negotiation — the rediscovery poll was never rescheduled and the SFU sat idle indefinitely while still connected to the signalling server, appearing healthy. The retry is now scheduled unconditionally.
+Fix two bugs that stopped the SFU streaming until it was restarted.
+
+A player that connected while no streamer was present is never added to the `peers` map, so
+`peers.get()` returned `undefined` when it disconnected. The guards in `onPeerDisconnected` and
+`onLayerPreference` tested `!== null`, which `undefined` passes, and the SFU crashed. Both now use
+the `if (peer)` form used elsewhere in the file.
+
+The SFU also only rescheduled its `listStreamers` poll when it still had a streamer. If the
+streamer dropped before sending its offer, nothing rescheduled the poll and the SFU sat idle,
+looking healthy, until it was restarted. The poll is now scheduled on every streamer disconnect,
+there is only ever one pending, and it is skipped when the signalling connection is down.

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -12,6 +12,7 @@ let signalServer = null;
 let mediasoupRouter;
 let streamer = null;
 let peers = new Map();
+let streamerSearchTimer = null;
 let dataRouter;
 let scalabilityMode = "L1T1"; // Scalability mode defaults to L1T1 and is set by the offer from the streamer
 
@@ -121,6 +122,34 @@ async function createDataRouter() {
     };
 }
 
+// Sends a message to the signalling server, but only while the connection is up. ws throws if the
+// socket is still connecting and raises an error event if it has closed, so anything that can run
+// after a disconnect (timers, close handlers) has to send through here.
+function sendToSignalServer(message) {
+    if (!signalServer || signalServer.readyState !== WebSocket.OPEN) {
+        return false;
+    }
+    signalServer.send(JSON.stringify(message));
+    return true;
+}
+
+// Asks for the streamer list again after a delay. Only one search is ever pending, so repeated
+// disconnects cannot build up a backlog of listStreamers messages and duplicate subscriptions.
+function scheduleStreamerSearch() {
+    cancelStreamerSearch();
+    streamerSearchTimer = setTimeout(function() {
+        streamerSearchTimer = null;
+        sendToSignalServer({ type: 'listStreamers' });
+    }, config.retrySubscribeDelaySecs * 1000);
+}
+
+function cancelStreamerSearch() {
+    if (streamerSearchTimer !== null) {
+        clearTimeout(streamerSearchTimer);
+        streamerSearchTimer = null;
+    }
+}
+
 function connectSignalling(server) {
     console.log("Connecting to Signalling Server at %s", server);
     signalServer = new WebSocket(server);
@@ -128,7 +157,10 @@ function connectSignalling(server) {
     signalServer.addEventListener("error", result => { console.log(`Error: ${result.message}`); });
     signalServer.addEventListener("message", result => onSignallingMessage(result.data));
     signalServer.addEventListener("close", result => {
-        onStreamerDisconnected();
+        // Only clean up locally. Nothing can be sent on a closed socket, and the reconnect below
+        // asks for the streamer list again as soon as the new connection is identified.
+        cancelStreamerSearch();
+        teardownStreamer();
         console.log(`Disconnected from signalling server: ${result.code} ${result.reason}`);
         console.log("Attempting reconnect to signalling server...");
         setTimeout(() => {
@@ -162,9 +194,7 @@ async function onStreamerList(msg) {
 
     if (!success) {
         // did not subscribe to anything
-        setTimeout(function() {
-            signalServer.send(JSON.stringify({ type: 'listStreamers' }));
-        }, config.retrySubscribeDelaySecs * 1000);
+        scheduleStreamerSearch();
     }
 }
 
@@ -201,24 +231,34 @@ function getNextStreamerSCTPId() {
     return streamer.transport.getNextSctpStreamId();
 }
 
-function onStreamerDisconnected() {
-    console.log("Streamer disconnected");
+// Drops all players and closes anything we hold for the current streamer. Sends nothing, so it is
+// safe to call when the signalling connection has already gone away. Returns true if we still had
+// a streamer to tear down.
+function teardownStreamer() {
     disconnectAllPeers();
 
-    if (streamer !== null) {
-        for (const mediaProducer of streamer.producers) {
-            mediaProducer.close();
-        }
-        streamer.transport.close();
-        streamer = null;
-        signalServer.send(JSON.stringify({ type: 'stopStreaming' }));
+    if (streamer === null) {
+        return false;
     }
 
-    // Outside the guard above: this handler also runs when streamer is already null, and skipping
-    // the poll then leaves the SFU idle forever instead of waiting for the streamer to come back.
-    setTimeout(function() {
-        signalServer.send(JSON.stringify({ type: 'listStreamers' }));
-    }, config.retrySubscribeDelaySecs * 1000);
+    for (const mediaProducer of streamer.producers) {
+        mediaProducer.close();
+    }
+    streamer.transport.close();
+    streamer = null;
+    return true;
+}
+
+function onStreamerDisconnected() {
+    console.log("Streamer disconnected");
+
+    if (teardownStreamer()) {
+        sendToSignalServer({ type: 'stopStreaming' });
+    }
+
+    // The streamer can also drop before it sends us an offer, in which case there was no streamer
+    // to tear down. Search either way, or the SFU sits idle until someone restarts it.
+    scheduleStreamerSearch();
 }
 
 async function onPeerConnected(peerId) {

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -212,11 +212,13 @@ function onStreamerDisconnected() {
         streamer.transport.close();
         streamer = null;
         signalServer.send(JSON.stringify({ type: 'stopStreaming' }));
-
-        setTimeout(function() {
-            signalServer.send(JSON.stringify({ type: 'listStreamers' }));
-        }, config.retrySubscribeDelaySecs * 1000);
     }
+
+    // Outside the guard above: this handler also runs when streamer is already null, and skipping
+    // the poll then leaves the SFU idle forever instead of waiting for the streamer to come back.
+    setTimeout(function() {
+        signalServer.send(JSON.stringify({ type: 'listStreamers' }));
+    }, config.retrySubscribeDelaySecs * 1000);
 }
 
 async function onPeerConnected(peerId) {

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -374,7 +374,7 @@ async function onPeerAnswer(peerId, sdp) {
 function onPeerDisconnected(peerId) {
     console.log("Player %s disconnected", peerId);
     const peer = peers.get(peerId);
-    if (peer !== null) {
+    if (peer) {
         for (const consumer of peer.consumers) {
             consumer.close();
         }
@@ -401,7 +401,7 @@ function disconnectAllPeers() {
 function onLayerPreference(msg) {
     console.log("onLayerPreference: " + JSON.stringify(msg));
     const peer = peers.get(`${msg.playerId}`);
-    if (peer !== null) {
+    if (peer) {
         for (const consumer of peer.consumers) {
             consumer.setPreferredLayers({ spatialLayer: msg.spatialLayer, temporalLayer: msg.temporalLayer });
         }


### PR DESCRIPTION
## Summary

Two bugs stop the SFU streaming. Each one needs an SFU restart to clear. Both were found on a live deployment serving one Unreal Engine streamer to browser players.

## Bug 1: the SFU crashes when a player disconnects

`peers` is a `Map`, so `peers.get()` returns `undefined` for an id that is not in it. `onPeerDisconnected` and `onLayerPreference` guard that result with `!== null`, and `undefined !== null` is true, so the guards do nothing.

`onPeerConnected` returns early when no streamer is connected, and never adds the player to the map. When that player leaves, `onPeerDisconnected` reads `peer.consumers` off `undefined` and the process exits.

To reproduce:

1. Start the SFU.
2. Do not connect a streamer.
3. Open the player page and select the SFU.
4. Close the page.
5. The SFU exits.

From the deployment:

```
Player Player64 joined
No streamer connected, ignoring player.
Player Player64 disconnected
TypeError: Cannot read properties of undefined (reading 'consumers')
    at onPeerDisconnected (/SFU/sfu_server.js:378:37)
    at onSignallingMessage (/SFU/sfu_server.js:431:9)
```

This is a regression. Both guards were `!= null` until commit 96066d67 (#802), and `undefined != null` is false, so the old guards worked.

## Bug 2: the SFU never looks for the streamer again

`onStreamerDisconnected` schedules another `listStreamers` message, but only inside the `if (streamer !== null)` block. The handler also runs when `streamer` is already null — for example when the streamer drops after the SFU subscribes but before it sends its offer. The subscribe succeeded, so `onStreamerList` does not schedule a retry either. Nothing polls again.

The SFU keeps its signalling connection, so the pod stays ready and the process stays alive, but no video flows. On the deployment it stayed like that for hours while the streamer reconnected many times. Restarting the pod fixed it immediately.

## Bug 3: the retry timer can crash the SFU during a reconnect

Found while fixing bug 2, and already present on master. The retry sends on `signalServer` from inside a `setTimeout`. If the signalling connection drops in the meantime, the SFU reconnects after 2 seconds and the retry fires 10 seconds after that against whatever socket is current. `ws.send()` throws when the socket is still connecting, and the throw is inside a timer callback with no handler, so the process exits.

Master reaches this through the `onStreamerList` retry. Moving the other retry out of the `streamer !== null` block, as the first version of this PR did, made it reachable from every signalling disconnect as well.

## Changes

All in `SFU/sfu_server.js`.

- `onPeerDisconnected` and `onLayerPreference` now guard with `if (peer)`, matching `setupPeerDataChannels` and `setupStreamerDataChannels`.
- The retry moves into `scheduleStreamerSearch()`, used by both `onStreamerList` and `onStreamerDisconnected`. It keeps one cancellable timer, so repeated disconnects cannot stack up polls, which would otherwise turn into duplicate `subscribe` messages.
- Sends that can run after a disconnect go through `sendToSignalServer()`, which drops the message unless the socket is open.
- Local cleanup moves out of `onStreamerDisconnected` into `teardownStreamer()`. The signalling close handler now calls that and cancels any pending search, rather than running the whole disconnect path: it cannot send on a closed socket, and the reconnect asks for the streamer list again as soon as it is identified.

## Tests

A harness starts an unmodified `sfu_server.js` and connects a mock signalling server to it. The harness sends the same JSON messages as the real signalling server and checks the replies. Mediasoup starts as usual, and no SFU internals are replaced. Every test ran against three versions: `master`, the first version of this PR, and this branch.

### Test 1: a player disconnects when no streamer is connected

Messages: `identify`, `streamerList` with no ids, `playerConnected`, `playerDisconnected`.

| Version | Result |
|---|---|
| `master` | Exits with code 1 and `TypeError: Cannot read properties of undefined (reading 'consumers')`. |
| First version | Keeps running. |
| This branch | Keeps running. |

### Test 2: the streamer disconnects before negotiation

Messages: `identify`, `streamerList` with the id `DefaultStreamer`, then `streamerDisconnected` once the SFU sends `subscribe`. No offer is sent, so `streamer` is null when `onStreamerDisconnected` runs. The harness then waits for another `listStreamers`.

The list holds a valid id on purpose. The subscribe succeeds, so `onStreamerList` cannot be the source of the retry, which isolates the bug.

| Version | Result |
|---|---|
| `master` | No further `listStreamers`. The SFU is stalled. |
| First version | A `listStreamers` arrives after the retry delay. |
| This branch | A `listStreamers` arrives after the retry delay. |

### Test 3: the signalling server dies and the reconnect hangs

The harness drops the SFU's connection, then holds the port open as a plain TCP listener that never completes the websocket handshake, so the reconnect sits in the connecting state while the pending retry fires.

| Version | Result |
|---|---|
| `master` | Exits with code 1 and `Error: WebSocket is not open: readyState 0 (CONNECTING)`. |
| First version | Same crash. |
| This branch | Keeps running and keeps reconnecting. |

### Other checks

- `node --check SFU/sfu_server.js` passes.
- The SFU starts and mediasoup initialises normally.

## Other branches

| Branch | Bug 1 | Bug 2 | Bug 3 |
|---|---|---|---|
| master | yes | yes | yes |
| UE5.8 | yes | yes | yes |
| UE5.7 | yes | yes | yes |
| UE5.6 | yes | yes | yes |
| UE5.5 | yes | yes | yes |
| UE5.4 | no | yes | yes |
| UE5.3 | no | yes | yes |
| UE5.2 and older | no | n/a | n/a |

UE5.4 and older use `!= null`, so bug 1 is not there. Bug 2 and bug 3 start at UE5.3, where the retry was added. UE5.2 and older have no retry.

UE5.6, UE5.7 and UE5.8 have all three bugs, and the affected functions are identical to master, so the backports should apply cleanly.

Please add the `auto-backport` label along with `auto-backport-to-UE5.8`, `auto-backport-to-UE5.7` and `auto-backport-to-UE5.6`.
