### PR TITLE
fix(frontend): stop mirroring quality settings into the legacy compat QP settings

### DIFF
--- a/.changeset/encoder-quality-compat-ratchet.md
+++ b/.changeset/encoder-quality-compat-ratchet.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.8": patch
+---
+
+Stop the streamer's encoder quality bounds drifting looser on every connect. `EncoderSettings.MinQuality`/`MaxQuality` from `initialSettings` were mirrored into the legacy `CompatQualityMin`/`CompatQualityMax` settings, whose listeners convert quality back to QP in floating point and send it as `Encoder.MinQP`/`Encoder.MaxQP`. A `MaxQuality` of 70 becomes `15.300000000000004`, which the streamer parses with an integer parse (flooring it to 15) and converts back by rounding (`100 * (1 - 15/51)` = 70.588 -> 71). Flooring one way and rounding the other is not the identity, and `initialSettings` is sent per player, so an application configured for 10/70 was running at 12/71 after one viewer, 14/73 after two, and eventually 25/76 — with the raised lower bound also taking away the encoder's room to drop quality under congestion. The mirror is removed: the streamer already applies `Encoder.MinQuality`/`Encoder.MaxQuality` verbatim, so nothing is lost, and the QP path is left in place for applications that send `MinQP`/`MaxQP` themselves.

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
@@ -519,6 +519,34 @@ describe('PixelStreaming', () => {
         expect(rtcPeerConnectionSpyFunctions.sendDataSpy).toHaveBeenCalled();
     });
 
+    it('should not mirror the streamer\'s quality settings into the legacy compat QP settings', () => {
+        mockHTMLMediaElement({ ableToPlay: true, readyState: 2 });
+
+        const config = new Config({ initialSettings: {ss: mockSignallingUrl}});
+        const pixelStreaming = new PixelStreaming(config);
+        pixelStreaming.connect();
+
+        establishMockedPixelStreamingConnection();
+
+        pixelStreaming.play();
+
+        const initialSettings = new InitialSettings();
+        initialSettings.EncoderSettings.MinQuality = 10;
+        initialSettings.EncoderSettings.MaxQuality = 70;
+        pixelStreaming._onInitialSettings(initialSettings);
+
+        // The quality settings themselves take the streamer's values.
+        expect(config.getNumericSettingValue(NumericParameters.MinQuality)).toEqual(10);
+        expect(config.getNumericSettingValue(NumericParameters.MaxQuality)).toEqual(70);
+
+        // The legacy compat settings must stay at their defaults. Mirroring 70 into
+        // CompatQualityMax sends Encoder.MinQP as 15.300000000000004, which the streamer floors to
+        // 15 and converts back by rounding to 70.588 -> 71, so the value it applies drifts one step
+        // looser per connect until it reaches a fixed point unrelated to the configured one.
+        expect(config.getNumericSettingValue(NumericParameters.CompatQualityMin)).toEqual(0);
+        expect(config.getNumericSettingValue(NumericParameters.CompatQualityMax)).toEqual(100);
+    });
+
     it('should send data through the data channel when emitUIInteraction is called', () => {
         mockHTMLMediaElement({ ableToPlay: true, readyState: 2 });
         

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -196,18 +196,23 @@ export class PixelStreaming {
         });
 
         // direct quality factor settings
+        //
+        // These deliberately do not mirror into CompatQualityMin/Max. The streamer applies
+        // Encoder.MinQuality/Encoder.MaxQuality verbatim, so mirroring only adds a lossy round trip
+        // through the legacy QP commands below: quality -> QP is computed in floating point here, and
+        // the streamer parses that string as an integer before converting back by rounding. Flooring
+        // one way and rounding the other is not the identity, so each pass loosened both bounds and
+        // the streamer's configured values drifted further on every connect.
         this.config._addOnNumericSettingChangedListener(NumericParameters.MinQuality, (newValue: number) => {
             Logger.Info('--------  Sending MinQuality  --------');
             this._webRtcController.sendEncoderMinQuality(newValue);
             Logger.Info('-------------------------------------------');
-            this.config.setNumericSetting(NumericParameters.CompatQualityMin, newValue);
         });
 
         this.config._addOnNumericSettingChangedListener(NumericParameters.MaxQuality, (newValue: number) => {
             Logger.Info('--------  Sending MaxQuality  --------');
             this._webRtcController.sendEncoderMaxQuality(newValue);
             Logger.Info('-------------------------------------------');
-            this.config.setNumericSetting(NumericParameters.CompatQualityMax, newValue);
         });
 
         // new quality value that gets scaled to qp for legacy reasons


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
An application's encoder quality bounds do not stay where it sets them. They loosen a little on every player connect, and after a handful of viewers they have settled somewhere unrelated to the configuration, with nothing in any log to say so.

A project configured with `EncoderMinQuality=10` and `EncoderMaxQuality=70` reads back as `12`/`71` while the first viewer is connected, `14`/`73` for the second, and converges on `25`/`76`. I found this in a 12-minute production session where the measured mean encoder QP tracked the drifted value rather than the configured one, so the encoder really is honouring it.

The path is a round trip through the legacy QP compat settings in which the two conversions are not inverses:

1. The streamer sends `EncoderSettings { MinQuality, MaxQuality }` in `initialSettings`, once per player.
2. The `MaxQuality` listener mirrors the value into `CompatQualityMax`.
3. The `CompatQualityMax` listener converts back to QP in floating point, `51 - (newValue / 100) * 51`, and sends it as `Encoder.MinQP`. For 70 that serialises as `15.300000000000004`.
4. The streamer parses it with an integer parse, **flooring** it to `15`, then converts QP back to quality by **rounding**: `100 * (1 - 15/51)` = 70.588 → `71`.

Floor one way, round the other, once per connect. `MinQuality` drifts the same way through `CompatQualityMin` → `Encoder.MaxQP`.

The ceiling drifting up is a bandwidth regression — three QP steps finer than configured is a large fraction more bitrate, and past a point the ceiling stops constraining anything. The floor drifting up is the half I would worry about more: raising `MinQuality` tightens the encoder's `MaxQP`, so a long-lived stream progressively loses its room to soften under congestion and drops frames instead. Neither is visible without dumping the CVars, which is why this survived so long.

## Solution
Remove the two mirror writes. The streamer applies `Encoder.MinQuality` and `Encoder.MaxQuality` verbatim — the handlers sit in the same block as the QP ones and do nothing but clamp to 0–100 — so for an application that sends quality, the compat round trip contributes nothing except the drift. Both bounds then hold at exactly what the application configured, for the lifetime of the process.

The QP direction is deliberately untouched: `MinQP`/`MaxQP` still mirror into `CompatQuality*` for applications that send QP in `EncoderSettings`, which is what that path exists for.

I should say that removing the mirror is the smaller of two possible fixes. Rounding the conversion instead (`Math.round(51 - (newValue / 100) * 51)`) makes the floor an exact fixed point immediately and limits the ceiling to a single step, but it still cannot express `MaxQuality=70` exactly — 70 has no integer QP — so the drift becomes one step rather than none. Removing the mirror seemed better than making a lossy path slightly less lossy, but I will happily swap it if you would rather keep the compat settings in sync.

Two things I would rather raise than have found:

**This leaves the streamer's integer parse alone, and I think that is correct here.** `Encoder.MinQP` receives a value that this library sends as a float string; parsing it as an integer silently floors it. That is the other half of the asymmetry and it is worth a look on its own, but it is engine-side, and with the mirror gone nothing in the reference frontend reaches that handler any more. I did not want to make this PR depend on an engine change to be useful.

**The settings panel's Min/Max Quality sliders no longer initialise from the streamer.** `ConfigUI` renders the `CompatQuality*` pair, not the native `MinQuality`/`MaxQuality` pair, so those two sliders previously showed the streamer's values by virtue of the mirror and now sit at their defaults until the user moves them. Dragging them still works exactly as before — the compat listeners still send QP. The native settings *are* populated from `initialSettings` (that path is unchanged); they are simply not the ones the UI draws. Teaching `ConfigUI` to render the native pair would make the panel right again and is probably where this wants to end up, but it is a UI-library change with its own compatibility surface, so I left it out of a fix PR. Glad to add it here or in a follow-up, whichever you prefer.

## Documentation
None. A changeset is included; there is no documented behaviour that changes, since the drift was never the intended behaviour.

## Test Plan and Compatibility
A unit test in `PixelStreaming.test.ts` drives `_onInitialSettings` with `MinQuality: 10` / `MaxQuality: 70` and asserts the native settings take those values while `CompatQualityMin`/`CompatQualityMax` stay at their defaults. I checked it is load-bearing by reverting the source change and confirming it fails (`Expected: 0, Received: 10`) rather than passing vacuously.

`npx jest PixelStreaming.test.ts` — 26 passed. `npx eslint src` clean, and `npm run build` (cjs + esm) clean.

Verified end to end against a real project as well: with the mirror removed, `PixelStreaming2.Encoder.MinQuality`/`MaxQuality` read `10`/`70` on the first connect and stay there across repeated reconnects, where before they walked to `12`/`71` and then `14`/`73`. Worth noting for anyone reproducing this: a single connect looks almost right, so it takes three or four reconnects in one process for the drift to be obvious.

Behaviour is unchanged for an application that sends `MinQP`/`MaxQP`, and unchanged for anyone who never set quality bounds at all — the defaults are 0 and 100, and 0/100 are the two values the round trip happens to be stable at.
