### PR TITLE
[UE5.7] chore(deps): bump the npm_and_yarn group across 2 directories with 2 updates (#993)

### DIFF
--- a/Extras/eslint/plugin-check-copyright/package-lock.json
+++ b/Extras/eslint/plugin-check-copyright/package-lock.json
@@ -157,41 +157,41 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
+                "node": ">=18.18.0"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8200,9 +8200,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
Manual backport of #993 — the auto-backport bot failed here with merge conflicts.

## Why the automated backport failed

#993 is a lockfile-only Dependabot bump (`fast-uri` 3.1.5 → 3.1.7, `@humanfs/node` 0.16.6 → 0.16.8). The cherry-pick's root-`package-lock.json` hunk expects `fast-uri@3.1.5` as context, but this branch resolves `fast-uri@3.1.4` — its `fast-uri@^3` override floor is `^3.1.4` while master's is `^3.1.5`. Different floor, different resolved version, hunk doesn't apply.

The bot suggested backporting #952 first. That is not a real prerequisite — it would drag master's override floors onto this branch. This branch's own pins are kept as-is and the dependency is simply re-resolved instead.

## What this does

Runs `npm update fast-uri --package-lock-only` at the root and `npm update @humanfs/node --package-lock-only` in `Extras/eslint/plugin-check-copyright`, landing on exactly the versions master now has:

| Package | Before | After |
|---|---|---|
| `fast-uri` | 3.1.4 | 3.1.7 |
| `@humanfs/node` | 0.16.6 | 0.16.8 |
| `@humanfs/core` | 0.19.1 | 0.19.2 |
| `@humanfs/types` | — | 0.15.0 |

`fast-uri` 3.1.6/3.1.7 close six high-severity advisories (SSRF and host-confusion via IDN canonicalization, repeated percent-decoding, IPv6 normalization, percent-encoded scheme normalization, plus port and IP-literal validation). Both dependencies are dev-only transitive deps.

No `package.json` changes — the existing `^` override floors already admit these versions. Lockfiles only; no changeset needed.
