### PR TITLE
fix(platform_scripts): skip npm audit when installing dependencies

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -181,7 +181,9 @@ function setup_node() {
     # if node_modules doesnt exist or the package-lock file is newer than node_modules, install deps
     if [ ! -d node_modules ] || [ ../package-lock.json -nt node_modules ] || [ "$INSTALL_DEPS" == "1" ]; then
         echo "Installing dependencies..."
-        npm install
+        # --no-audit/--no-fund: neither is read by the startup path, and a slow
+        # registry audit blocks the server from starting for minutes.
+        npm install --no-audit --no-fund
     fi
 
     # log node version for audits

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -167,7 +167,9 @@ popd
 if "%INSTALL_DEPS%"=="1" (
     echo Installing dependencies...
     pushd "%SCRIPT_DIR%..\..\.."
-    call %NPM% install
+    rem --no-audit/--no-fund: neither is read by the startup path, and a slow
+    rem registry audit blocks the server from starting for minutes.
+    call %NPM% install --no-audit --no-fund
     popd
 )
 


### PR DESCRIPTION
## Problem

The `run-script-{linux,macos,windows}` healthcheck jobs fail on **master**, not just on dependency PRs. Confirmed by dispatching the workflow against unmodified master: [run 33827261012](https://github.com/EpicGames/PixelStreamingInfrastructure/actions/runs/33827261012) fails on all three platforms.

It went unnoticed because `healthcheck-platform-scripts.yml` only triggers on `SignallingWebServer/**`, and nothing had touched that path since Aug 12. The next PR to touch it (#995, a Dependabot bump) inherited the failure and looked like the culprit.

## Root cause

`common.sh` / `common.bat` run a bare `npm install`, which also runs `npm audit`. npm withholds its entire summary block (`added N packages, and audited M packages in Xs`) until the audit returns — so a slow audit is indistinguishable from a hang, and the server never starts.

Measured locally on an already-installed tree, so the audit was the only work left:

```
up to date, audited 1387 packages in 4m
real  4m11.790s
user  0m4.378s      <- ~4s CPU; the rest is network wait
```

The healthcheck allows `curl --retry 10 --retry-delay 20` ≈ 200s, so curl exhausts its retries and exits 7 before the server is up.

Supporting evidence:

- **Aug 12 (last green run):** `added 1373 packages, and audited 1387 packages in 16s`; whole job 68s.
- **Now:** silence after the same two deprecation warnings, with `npm install` still alive as an orphan process at job cleanup — on all three platforms, i.e. one shared external dependency.
- A diagnostic run with `--no-audit` completed `npm install` in **7s** on the same runner image.

## Fix

Pass `--no-audit --no-fund` at both install sites. Neither output is read by the startup path, and a registry audit shouldn't gate launching a dev server. This also removes the same multi-minute stall for anyone running `start.sh` locally, not just CI.

The underlying slowness is upstream at npm's registry and may pass on its own, but the scripts shouldn't be exposed to it.

## Verification

Locally, `start.sh` now proceeds through install → build Common/Signalling/Frontend → build Wilbur → launch (my machine then stops at an unrelated `sudo` password prompt that CI's passwordless sudo doesn't hit). This PR touches `SignallingWebServer/**`, so the healthcheck runs here and is the real check.

## Notes

- No changeset: consistent with prior platform-script-only changes (e.g. #955).
- CRLF line endings preserved in `common.bat`.
- Not included, but worth considering separately: raising the healthcheck's curl budget so a slow registry degrades instead of failing outright.
