### PR TITLE
[UE5.7] fix(platform_scripts): skip npm audit when installing dependencies (#998)

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -181,7 +181,9 @@ function setup_node() {
     # if node_modules doesnt exist or the package-lock file is newer than node_modules, install deps
     if [ ! -d node_modules ] || [ ../package-lock.json -nt node_modules ] || [ "$INSTALL_DEPS" == "1" ]; then
         echo "Installing dependencies..."
-        npm install
+        # --no-audit/--no-fund: neither is read by the startup path, and a slow
+        # registry audit blocks the server from starting for minutes.
+        npm install --no-audit --no-fund
     fi
 
     # log node version for audits

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -167,7 +167,9 @@ popd
 if "%INSTALL_DEPS%"=="1" (
     echo Installing dependencies...
     pushd "%SCRIPT_DIR%..\..\.."
-    call %NPM% install
+    rem --no-audit/--no-fund: neither is read by the startup path, and a slow
+    rem registry audit blocks the server from starting for minutes.
+    call %NPM% install --no-audit --no-fund
     popd
 )
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [fix(platform_scripts): skip npm audit when installing dependencies (#998)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/998)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)