### PR TITLE
[UE5.7] chore(deps): bump qs in the npm_and_yarn group across 1 directory (#995)

### DIFF
--- a/Extras/JSStreamer/package.json
+++ b/Extras/JSStreamer/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingcommon-ue5.7": "*",
-        "body-parser": "^1.20.4"
+        "body-parser": "^2.3.0"
     },
     "overrides": {
         "http-proxy-middleware": "2.0.8"

--- a/Signalling/package.json
+++ b/Signalling/package.json
@@ -39,9 +39,9 @@
         "typescript-eslint": "8.57.2"
     },
     "dependencies": {
-        "body-parser": "^1.20.4",
+        "body-parser": "^2.3.0",
         "cors": "^2.8.5",
-        "express": "^4.22.1",
+        "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.0.0",
         "hsts": "^2.2.0",

--- a/SignallingWebServer/package.json
+++ b/SignallingWebServer/package.json
@@ -33,9 +33,9 @@
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingsignalling-ue5.7": "*",
-        "body-parser": "^1.20.4",
+        "body-parser": "^2.3.0",
         "commander": "^12.0.0",
-        "express": "^4.22.1",
+        "express": "^5.2.1",
         "express-openapi": "^12.1.3",
         "jsonc": "^2.0.0"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
             "license": "MIT",
             "dependencies": {
                 "@epicgames-ps/lib-pixelstreamingcommon-ue5.7": "*",
-                "body-parser": "^1.20.4"
+                "body-parser": "^2.3.0"
             },
             "devDependencies": {
                 "@types/node": "^22.14.0",
@@ -119,6 +119,114 @@
                 "webpack-cli": "^6.0.1",
                 "webpack-dev-server": "^5.2.5",
                 "webpack-node-externals": "^3.0.0"
+            }
+        },
+        "Extras/JSStreamer/node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Extras/JSStreamer/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Extras/JSStreamer/node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Extras/JSStreamer/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "Extras/JSStreamer/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Extras/JSStreamer/node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "Extras/JSStreamer/node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "Extras/mediasoup-sdp-bridge": {
@@ -9390,7 +9498,6 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9970,6 +10077,12 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
         },
         "node_modules/is-regex": {
@@ -12949,6 +13062,15 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/one-time": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -13884,12 +14006,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -14448,6 +14571,32 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/router/node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/run-applescript": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -14966,14 +15115,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -17822,6 +17971,12 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        },
         "node_modules/write-file-atomic": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -18077,9 +18232,9 @@
             "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
-                "body-parser": "^1.20.4",
+                "body-parser": "^2.3.0",
                 "cors": "^2.8.5",
-                "express": "^4.22.1",
+                "express": "^5.2.1",
                 "express-rate-limit": "^8.5.1",
                 "helmet": "^8.0.0",
                 "hsts": "^2.2.0",
@@ -18113,15 +18268,330 @@
                 "@epicgames-ps/lib-pixelstreamingcommon-ue5.7": "^0.1.5"
             }
         },
+        "Signalling/node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "Signalling/node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/body-parser/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "Signalling/node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "Signalling/node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "Signalling/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "Signalling/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/negotiator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+            "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/negotiator/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "Signalling/node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "Signalling/node_modules/type-is/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "SignallingWebServer": {
             "name": "@epicgames-ps/wilbur",
             "version": "3.2.0",
             "license": "MIT",
             "dependencies": {
                 "@epicgames-ps/lib-pixelstreamingsignalling-ue5.7": "*",
-                "body-parser": "^1.20.4",
+                "body-parser": "^2.3.0",
                 "commander": "^12.0.0",
-                "express": "^4.22.1",
+                "express": "^5.2.1",
                 "express-openapi": "^12.1.3",
                 "jsonc": "^2.0.0"
             },
@@ -18141,6 +18611,56 @@
                 "typescript-eslint": "8.57.2"
             }
         },
+        "SignallingWebServer/node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "SignallingWebServer/node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/body-parser/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "SignallingWebServer/node_modules/commander": {
             "version": "12.1.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -18148,6 +18668,271 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "SignallingWebServer/node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "SignallingWebServer/node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "SignallingWebServer/node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "SignallingWebServer/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "SignallingWebServer/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/negotiator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+            "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/negotiator/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "SignallingWebServer/node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "SignallingWebServer/node_modules/type-is/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         }
     }


### PR DESCRIPTION
Manual backport of #995 to `UE5.7` (the automatic backport failed — see below).

### Why the automatic backport failed

Not a real dependency prerequisite. The bot suggested backporting #952/#905 first, but those are unrelated — `UE5.6`, `UE5.7` and `UE5.8` all already carry identical `express`/`body-parser`/`qs` state. The conflict was purely contextual:

- `Extras/JSStreamer/package.json` and `SignallingWebServer/package.json` have the workspace package name (`...-ue5.7` vs master's `...-ue5.8`) on the line immediately above `body-parser`, so the bumped line collided with the branch's own suffix.
- `package-lock.json` could not auto-merge for the same reason.

`UE5.8` applied cleanly because master still carries `ue5.8` suffixes.

### What this PR does

- `express` `^4.22.1` → `^5.2.1` and `body-parser` `^1.20.4` → `^2.3.0` in `Signalling`, `SignallingWebServer` and `Extras/JSStreamer` — identical to #995, with this branch's package-name suffixes preserved.
- `package-lock.json` regenerated **on this branch** rather than taken from master, then `npm update qs` to re-resolve. Result: a single `qs` at **6.16.0**, which is the point of #995.

### Note on the lockfile diff shape

Master's lockfile diff was net-negative (`+296/-617`) because master had already moved `webpack-dev-server` to `^6.0.0`, which dropped the whole Express 4 subtree. `UE5.7` still pins `webpack-dev-server@^5` (`^5.2.5`), which depends on `express@^4.22.1`, so Express 4 stays in the **dev-only** tree here and the diff is net-additive (`+830/-45`).

That does not weaken the fix: the root `overrides` entry `"qs@^6": "^6.15.2"` forces every consumer — including Express 4 — onto `qs@6.16.0`, so there is exactly one `qs` in the tree. Bumping `webpack-dev-server` to `^6` was deliberately left out; it is not part of #995 and belongs in its own change.

### Verification

- `npm ci && npm run build`: `Common`, `Signalling`, `SignallingWebServer`, `SFU`, `Frontend/library`, `Frontend/ui-library`, `SS_Test` and `JSStreamer` all build.
- `Frontend/implementations/react` fails to build, but **pre-existing on this branch and unrelated** — a `.tsx`/JSX loader config error plus `html-loader` import resolution. This commit changes no `webpack`, `html-loader` or `react` resolution (both pin `webpack@5.107.2`, `html-loader@5.1.0` before and after).
- Express usage in `Signalling/src/WebServer.ts` is byte-identical to master, and contains none of the Express 5 breaking patterns (no wildcard/optional route params, no `app.del`, no `req.param()`, no `res.send(status)`).

### Reviewer note

Despite the `chore(deps): bump qs` title, #995 is an **Express 4 → 5 major upgrade**. Worth a deliberate look before merging onto a release branch.
