### PR TITLE
chore(deps): bump browserslist to resolve CVE-2026-73088

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5416,9 +5416,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.32",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-            "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+            "version": "2.11.21",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+            "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5541,9 +5541,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.9",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+            "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
             "dev": true,
             "funding": [
                 {
@@ -5561,11 +5561,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
+                "baseline-browser-mapping": "^2.11.20",
+                "caniuse-lite": "^1.0.30001810",
+                "electron-to-chromium": "^1.5.420",
+                "node-releases": "^2.0.54",
+                "update-browserslist-db": "^1.3.2"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5737,9 +5737,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
                 {
@@ -7295,9 +7295,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.361",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-            "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+            "version": "1.5.422",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+            "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
             "dev": true,
             "license": "ISC"
         },
@@ -12877,9 +12877,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.46",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17071,9 +17071,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
Resolves Dependabot alert #238.

| | |
|---|---|
| Package | `browserslist` (npm), transitive, **development** scope |
| Advisory | [GHSA-73wf-gq98-2v4g](https://github.com/browserslist/browserslist/security/advisories/GHSA-73wf-gq98-2v4g) / CVE-2026-73088 |
| Severity | High, CVSS 7.5 (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`) — availability only |
| Vulnerable | `<= 4.28.6`, patched in 4.28.7 |

`browserslist` was resolved at **4.28.2**. An unguarded `for...in` in `normalizeStats()` means a poisoned `browserslist-stats.json` placed anywhere in the directory tree crashes every subsequent `browserslist()` call — including calls made internally by Babel, webpack, Autoprefixer and PostCSS, for any query. Dev-scope only, so this is a build/CI availability risk rather than anything in shipped output.

### The change

Lockfile-only. `npm update browserslist --package-lock-only` re-resolves to **4.28.9**; no manifest ranges needed changing, and there is no `browserslist` entry in root `overrides` blocking it. The existing requirements — `^4.24.0` (`@babel/helper-compilation-targets`), `^4.28.1` (`webpack`), `>= 4.21.0` (`update-browserslist-db`) — are all satisfied by the patched version.

Six packages move, all browserslist's own data chain:

```
browserslist              4.28.2       → 4.28.9
caniuse-lite              1.0.30001793 → 1.0.30001810
electron-to-chromium      1.5.361      → 1.5.422
node-releases             2.0.46       → 2.0.54
baseline-browser-mapping  2.10.32      → 2.11.21
update-browserslist-db    1.2.3        → 1.3.2
```

### Verification

`npm ci && npm run build` passes clean across all workspaces, including `Frontend/implementations/react`.

### Notes

- `UE5.8`, `UE5.7` and `UE5.6` are all on 4.28.2 as well and need the same fix. Backporting separately — the lockfile should be re-resolved on each branch rather than cherry-picked, since the branches carry different workspace self-versions and dependency state.
- There is no `.github/dependabot.yml` in the repo, so Dependabot runs on defaults. This alert sat open for six days with no bot PR, while the `qs` one got a PR within a day. Might be worth checking the repo's Dependabot settings for whether dev-scope security PRs are being suppressed.
