### PR TITLE
[UE5.6] chore(deps): bump browserslist to resolve CVE-2026-73088 (#1009)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5180,9 +5180,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.32",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-            "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+            "version": "2.11.21",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+            "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5314,9 +5314,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.9",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+            "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
             "dev": true,
             "funding": [
                 {
@@ -5334,11 +5334,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
+                "baseline-browser-mapping": "^2.11.20",
+                "caniuse-lite": "^1.0.30001810",
+                "electron-to-chromium": "^1.5.420",
+                "node-releases": "^2.0.54",
+                "update-browserslist-db": "^1.3.2"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5510,9 +5510,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
                 {
@@ -7148,9 +7148,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.363",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz",
-            "integrity": "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==",
+            "version": "1.5.422",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+            "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
             "dev": true,
             "license": "ISC"
         },
@@ -12722,9 +12722,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.46",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17080,9 +17080,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "fast-uri@^3": "^3.1.4",
         "shell-quote": "^1.10.0",
         "js-yaml@^3": "^3.15.1",
-        "js-yaml@^4": "^4.3.1"
+        "js-yaml@^4": "^4.3.1",
+        "browserslist@^4": "^4.28.7"
     },
     "dependencies": {}
 }


### PR DESCRIPTION
Backport of #1009 to `UE5.6`. Resolves Dependabot alert #238 on this branch.

| | |
|---|---|
| Package | `browserslist` (npm), transitive, **development** scope |
| Advisory | [GHSA-73wf-gq98-2v4g](https://github.com/browserslist/browserslist/security/advisories/GHSA-73wf-gq98-2v4g) / CVE-2026-73088 |
| Severity | High, CVSS 7.5 — availability only |
| Vulnerable | `<= 4.28.6`, patched in 4.28.7 |

`browserslist` was resolved at **4.28.2** here. An unguarded `for...in` in `normalizeStats()` means a poisoned `browserslist-stats.json` anywhere in the directory tree crashes every subsequent `browserslist()` call, including calls made internally by Babel, webpack, Autoprefixer and PostCSS. Dev-scope only, so it's a build/CI availability risk, not something in shipped output.

### Why this isn't a straight cherry-pick of #1009

Two reasons, both worth knowing for future dependency backports:

1. **The lockfile can't be patched across branches.** `UE5.6`'s `package-lock.json` differs from master's by thousands of lines (96 shared packages resolve to different versions; each side has 100+ packages the other lacks). Cherry-picking #1009 conflicts on a single stale hunk — `electron-to-chromium` is 1.5.363 here vs 1.5.361 on master. So the lockfile is re-resolved on this branch instead of imported.
2. **`npm update browserslist` is a no-op on this branch.** On master it moved 4.28.2 → 4.28.9 unaided. Here npm considers the existing entry already satisfied and won't budge, however many times it runs. It only re-resolves once an `overrides` pin is present.

So this PR adds a two-line `overrides` entry — matching how `qs`, `ws`, `fast-uri` and `brace-expansion` are already pinned in this repo — and then re-resolves:

```jsonc
"browserslist@^4": "^4.28.7"
```

Result: `browserslist` **4.28.2 → 4.28.9**, plus its five data-chain companions (`caniuse-lite`, `electron-to-chromium`, `node-releases`, `baseline-browser-mapping`, `update-browserslist-db`). 12 version lines change in the lockfile; nothing else.

### Verification

`npm ci && npm run build` builds every workspace except `Frontend/implementations/react`, which fails on a **pre-existing, unrelated** `.tsx`/JSX loader plus `html-loader` import error already present on this branch. This commit changes no `webpack`, `html-loader`, `react` or `@babel/preset` resolution — `webpack` stays at 5.107.2 and `html-loader` at 5.1.0 before and after. The same build is clean on master.
