### PR TITLE
ci(dependabot): add config so release branches get dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,124 @@
+# Dependabot configuration.
+#
+# This file is only ever read from the default branch (master). The
+# `target-branch` entries below are what let a single config here drive updates
+# on the release branches -- do not copy this file onto UE5.x.
+#
+# Why the release branches are listed at all: Dependabot *security* updates
+# (the alert-driven ones) are raised against the default branch only, and
+# `target-branch` applies to version updates exclusively. So an alert like
+# CVE-2026-73088 produces a PR on master and nothing on UE5.8/5.7/5.6. Before
+# this config existed, every such fix had to be backported by hand -- and a
+# lockfile patch does not cherry-pick across these branches, because their
+# dependency graphs have diverged (UE5.7's lockfile differs from master's by
+# thousands of lines). The scheduled version updates below let Dependabot
+# resolve each branch's lockfile natively instead, which is the only way to get
+# a correct result.
+#
+# Two npm roots exist: the workspace root (covering all 13 workspaces via the
+# shared lockfile) and the standalone eslint plugin, which has its own lockfile.
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------- master ---
+  # Security updates land here automatically and need no configuration; these
+  # entries add the scheduled version updates.
+  - package-ecosystem: npm
+    directories:
+      - "/"
+      - "/Extras/eslint/plugin-check-copyright"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-development:
+        dependency-type: development
+        update-types: ["minor", "patch"]
+      npm-production:
+        dependency-type: production
+        update-types: ["minor", "patch"]
+
+  # -------------------------------------------------------- release: UE5.8 ---
+  # Majors are ignored on release branches: a breaking upgrade should be a
+  # deliberate change, not a scheduled one. (A "bump qs" PR that was really an
+  # Express 4 -> 5 major is what prompted this.) Patches and minors still flow,
+  # which is what picks up security fixes here.
+  - package-ecosystem: npm
+    target-branch: UE5.8
+    directories:
+      - "/"
+      - "/Extras/eslint/plugin-check-copyright"
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-development:
+        dependency-type: development
+        update-types: ["minor", "patch"]
+      npm-production:
+        dependency-type: production
+        update-types: ["minor", "patch"]
+
+  # -------------------------------------------------------- release: UE5.7 ---
+  - package-ecosystem: npm
+    target-branch: UE5.7
+    directories:
+      - "/"
+      - "/Extras/eslint/plugin-check-copyright"
+    schedule:
+      interval: weekly
+      day: wednesday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-development:
+        dependency-type: development
+        update-types: ["minor", "patch"]
+      npm-production:
+        dependency-type: production
+        update-types: ["minor", "patch"]
+
+  # -------------------------------------------------------- release: UE5.6 ---
+  - package-ecosystem: npm
+    target-branch: UE5.6
+    directories:
+      - "/"
+      - "/Extras/eslint/plugin-check-copyright"
+    schedule:
+      interval: weekly
+      day: thursday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      npm-development:
+        dependency-type: development
+        update-types: ["minor", "patch"]
+      npm-production:
+        dependency-type: production
+        update-types: ["minor", "patch"]
+
+  # ------------------------------------------------------- github-actions ---
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies


### PR DESCRIPTION
Adds `.github/dependabot.yml`. The repo currently has **no Dependabot config at all**, which is the root cause of the recurring backport pain around dependency PRs.

### The problem

Without a config, Dependabot only ever looks at the default branch. So every dependency fix lands on `master` and then has to be backported by hand — and lockfile patches don't cherry-pick across these branches:

| Branch | `package-lock.json` diff vs master |
|---|---|
| UE5.8 | 23 insertions / 23 deletions |
| UE5.7 | **3241** / 2570 |
| UE5.6 | **2871** / 2175 |

Between master and UE5.7, 96 shared packages resolve to different versions, 113 packages exist only on master and 123 only on UE5.7. That's why UE5.8 backports sail through and 5.7/5.6 fail on essentially every dependency PR — most recently #995 and #1009, where the conflict was a single stale line (`electron-to-chromium` 1.5.363 vs 1.5.361).

A lockfile is a generated artifact of the whole dependency graph. Patching master's copy onto a branch with a different graph isn't meaningful, so this isn't fixable by tuning the backport action — its `conflictResolution` only offers `abort`, `commit` or `theirs`, and `theirs` would drop master's entire lockfile (wrong workspace suffixes and all) onto UE5.7.

### The fix

Let Dependabot resolve each branch's lockfile natively, via `target-branch` entries for UE5.8, UE5.7 and UE5.6. Covers both npm roots — the workspace root (all 13 workspaces share one lockfile) and the standalone `Extras/eslint/plugin-check-copyright`, which has its own — plus a `github-actions` entry.

Schedules are staggered Monday→Thursday so the four branches don't all fire at once, and minor/patch updates are grouped by dependency type to keep PR volume down.

### Majors are ignored on release branches

```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

A breaking upgrade on a shipped branch should be a deliberate decision, not a scheduled one. #995 is the cautionary case: titled `chore(deps): bump qs`, it was actually an **Express 4 → 5 major upgrade**, and with `autoMerge: true` in `.backportrc.json` it self-merged onto UE5.8 with no review. Patches and minors still flow, which is what picks up security fixes.

### One limitation worth being explicit about

`target-branch` governs **version** updates only. Dependabot *security* updates — the alert-driven ones — are raised against the default branch exclusively and cannot be retargeted; the alerts themselves are only generated from the default branch's dependency graph. This is long-standing and unresolved ([community#15027](https://github.com/orgs/community/discussions/15027), [options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)).

So a future alert like CVE-2026-73088 will still produce a PR on `master` only. The difference is that the release branches now pick the same fix up through their scheduled version updates, with correctly resolved lockfiles, instead of needing a manual backport each time. For anything urgent you'd still fix it by hand on each branch — but that becomes the exception rather than the routine.

### Notes

- This file is read **only** from the default branch. It should not be backported to UE5.x — the `target-branch` entries are what reach those branches. Worth not labelling this PR `auto-backport`.
- Not addressed here: the six-day gap before alert #238 got any bot PR at all, while `qs` got one within a day. Worth a look at the repo's Dependabot security-update settings separately.
