### PR TITLE
ci(dependabot): batch github-actions updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,9 +116,17 @@ updates:
         update-types: ["minor", "patch"]
 
   # ------------------------------------------------------- github-actions ---
+  # Batched into a single PR. Adding this ecosystem opened five separate PRs at
+  # once (#1014-#1018), because nothing had ever checked the workflows before
+  # and Dependabot runs every entry immediately when a config is first merged.
+  # Grouping keeps a monthly sweep to one reviewable PR.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
+    open-pull-requests-limit: 3
     labels:
       - dependencies
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Follow-up to #1013. Batches `github-actions` updates into a single PR.

### What went wrong

The `github-actions` entry I added in #1013 had no `groups` and no `open-pull-requests-limit`, unlike the npm entries. Since nothing had ever checked the workflows before — and Dependabot runs every entry immediately when a config is first merged, ignoring the schedule — it fanned out into five separate PRs at once (#1014–#1018). Five is the default limit, so there may be more queued behind them.

```yaml
    open-pull-requests-limit: 3
    groups:
      github-actions:
        patterns: ["*"]
```

A monthly sweep now arrives as one reviewable PR.

### Note: those five bumps are not optional

While checking whether they were safe to take, it turned out they're time-sensitive. **Node 20 is removed from GitHub Actions runners on 23 September 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) — about two weeks out. Every currently-pinned version in this repo runs on node16 or node20:

| Action | Pinned | Runtime | Proposed | Runtime |
|---|---|---|---|---|
| `actions/checkout` | v4 | node20 | v7 | node24 |
| `actions/upload-artifact` | v4 | node20 | v7 | node24 |
| `peter-evans/create-pull-request` | v6 | node20 | v8 | node24 |
| `docker/build-push-action` | v3 | **node16** | v7 | node24 |
| `isbang/compose-action` | v1.5.1 | **node16** | v3.1.0 | node24 |

Actions that explicitly require node20 stop working after that date, so #1014–#1018 are a required migration, not noise. I checked each against how this repo actually uses it and found no blocking incompatibility:

- **`actions/checkout` v4 → v7** — only `ref` is ever passed, unchanged across majors. v7 blocks fork-PR checkout under `pull_request_target`/`workflow_run`, but the only workflow using `pull_request_target` is `backport.yml`, which doesn't check out at all.
- **`actions/upload-artifact` v4 → v7** — `name` and `path` both still present. v7's non-zipped upload is opt-in via `archive: false`, which defaults to `true`, so artifact format is unchanged.
- **`peter-evans/create-pull-request` v6 → v8** — v7 renamed `git-token` → `branch-token`, changed the `pull-request-operation` output, and dropped the `PULL_REQUEST_NUMBER` env var. `changesets-prune-master.yml` uses none of them (`token`, `base`, `branch`, `delete-branch`, `title`, `commit-message`, `body-path` only).
- **`docker/build-push-action` v3 → v7** — `context`, `tags`, `push` and `file` all still supported.
- **`isbang/compose-action` v1.5.1 → v3.1.0** — `compose-file` and `up-flags` both still supported.

The Node 24 runner floor (v2.327.1+) that several of these introduce is irrelevant here: all workflows run on GitHub-hosted `ubuntu-latest` / `windows-latest` / `macos-latest`, with no self-hosted runners.

Two things worth doing separately, out of scope here:

1. **`isbang/compose-action` has been transferred to `hoverkraft-tech/compose-action`.** The old path still resolves by redirect, but the `uses:` references are worth renaming explicitly.
2. **`create-pull-request` v7+ can sign its commits** as `github-actions[bot]` with `GITHUB_TOKEN`, or as your own bot with a GitHub App token. `changesets-prune-master.yml` currently uses `AUTOMATION_PAT`, so its commits are unsigned — switching to a GitHub App token would fix that, and would also address the unsigned commits the backport action produces.
