### PR TITLE
ci(dependabot): scope config to the release branches only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,31 +17,15 @@
 #
 # Two npm roots exist: the workspace root (covering all 13 workspaces via the
 # shared lockfile) and the standalone eslint plugin, which has its own lockfile.
+#
+# Deliberately scoped to the release branches only. master needs nothing here:
+# it already gets alert-driven security PRs with no configuration, and adding
+# scheduled version updates for it just produced review load nobody asked for.
+# There is no github-actions entry for the same reason -- bump those by hand.
 
 version: 2
 
 updates:
-  # ---------------------------------------------------------------- master ---
-  # Security updates land here automatically and need no configuration; these
-  # entries add the scheduled version updates.
-  - package-ecosystem: npm
-    directories:
-      - "/"
-      - "/Extras/eslint/plugin-check-copyright"
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-    groups:
-      npm-development:
-        dependency-type: development
-        update-types: ["minor", "patch"]
-      npm-production:
-        dependency-type: production
-        update-types: ["minor", "patch"]
-
   # -------------------------------------------------------- release: UE5.8 ---
   # Majors are ignored on release branches: a breaking upgrade should be a
   # deliberate change, not a scheduled one. (A "bump qs" PR that was really an
@@ -114,11 +98,3 @@ updates:
       npm-production:
         dependency-type: production
         update-types: ["minor", "patch"]
-
-  # ------------------------------------------------------- github-actions ---
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: monthly
-    labels:
-      - dependencies


### PR DESCRIPTION
Scales #1013 back to what was actually needed. Supersedes #1030, which can be closed.

### What went wrong

#1013 solved the real problem — release branches never got dependency updates, so every fix had to be hand-backported, and lockfile patches don't cherry-pick across these branches. But it also added two things nobody asked for:

- a **master npm** entry, giving master scheduled *version* updates it never had
- a **github-actions** entry, for an ecosystem nothing had ever checked

On first merge Dependabot runs every entry immediately, so those two produced **10 of the 16 PRs** that appeared (#1014–#1018, #1020, #1024–#1027). The three release-branch entries produced 2 tidy grouped PRs each, exactly as intended.

master never needed an npm entry: it already receives alert-driven security PRs with no configuration at all. That's how #995 and #1009 arrived.

### After this change

Three entries, all npm, all `target-branch`:

| Target | Cadence | Majors | Grouping |
|---|---|---|---|
| UE5.8 | weekly, Tuesday | ignored | dev / prod |
| UE5.7 | weekly, Wednesday | ignored | dev / prod |
| UE5.6 | weekly, Thursday | ignored | dev / prod |

Nothing targets master, and there's no `github-actions` entry — those get bumped by hand. Net effect: minor/patch updates flow to the release branches with correctly resolved per-branch lockfiles, and master's behaviour is exactly what it was before #1013.

### The 16 open PRs

Closing a Dependabot PR manually is equivalent to `@dependabot close` — it won't be recreated for that same version, only when a newer one appears ([docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates)). So #1020 and #1024–#1027 can be closed outright.

**#1014–#1018 are a different case and shouldn't just be closed.** They're not noise this config invented — they surface a pre-existing problem. **Node 20 is removed from Actions runners on 23 September 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)), and every action pinned in this repo runs on node16 or node20:

| Action | Pinned | Runtime |
|---|---|---|
| `actions/checkout` | v4 | node20 |
| `actions/upload-artifact` | v4 | node20 |
| `peter-evans/create-pull-request` | v6 | node20 |
| `docker/build-push-action` | v3 | node16 |
| `isbang/compose-action` | v1.5.1 | node16 |

Those workflows break on that date regardless of Dependabot. I checked all five bumps against this repo's actual usage and found no blocking incompatibility — details in #1030's description, which is worth reading before closing it. Merging them, or doing the runtime bumps by hand, both work; ignoring them doesn't.
