### PR TITLE
ci(dependabot): ignore packages that diverge across workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,16 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # These span workspaces that deliberately sit on different versions --
+      # ws is ^8 in Common/Signalling/SS_Test but ^7 in SFU, and mediasoup is
+      # pinned exact in mediasoup-sdp-bridge but a caret range in SFU. A
+      # grouped update unifies each package on one version across the whole
+      # monorepo, which levelled ws down from ^8 to ^7 (bypassing the
+      # "ws@^8" overrides pin) and skewed mediasoup-client away from the
+      # mediasoup server it bridges. Both need coordinated manual upgrades.
+      - dependency-name: "ws"
+      - dependency-name: "mediasoup"
+      - dependency-name: "mediasoup-client"
     groups:
       npm-development:
         dependency-type: development
@@ -68,6 +78,16 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # These span workspaces that deliberately sit on different versions --
+      # ws is ^8 in Common/Signalling/SS_Test but ^7 in SFU, and mediasoup is
+      # pinned exact in mediasoup-sdp-bridge but a caret range in SFU. A
+      # grouped update unifies each package on one version across the whole
+      # monorepo, which levelled ws down from ^8 to ^7 (bypassing the
+      # "ws@^8" overrides pin) and skewed mediasoup-client away from the
+      # mediasoup server it bridges. Both need coordinated manual upgrades.
+      - dependency-name: "ws"
+      - dependency-name: "mediasoup"
+      - dependency-name: "mediasoup-client"
     groups:
       npm-development:
         dependency-type: development
@@ -91,6 +111,16 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # These span workspaces that deliberately sit on different versions --
+      # ws is ^8 in Common/Signalling/SS_Test but ^7 in SFU, and mediasoup is
+      # pinned exact in mediasoup-sdp-bridge but a caret range in SFU. A
+      # grouped update unifies each package on one version across the whole
+      # monorepo, which levelled ws down from ^8 to ^7 (bypassing the
+      # "ws@^8" overrides pin) and skewed mediasoup-client away from the
+      # mediasoup server it bridges. Both need coordinated manual upgrades.
+      - dependency-name: "ws"
+      - dependency-name: "mediasoup"
+      - dependency-name: "mediasoup-client"
     groups:
       npm-development:
         dependency-type: development


### PR DESCRIPTION
Adds `ignore` rules for `ws`, `mediasoup` and `mediasoup-client` to all three release-branch entries.

### What went wrong

The grouping I added in #1013 caused the six npm PRs (#1019, #1021–#1023, #1028, #1029) to fail CI on every release branch. A grouped update unifies each package on a **single version across the whole monorepo**, but these packages deliberately differ per workspace:

| Workspace | `ws` | `mediasoup` | `mediasoup-client` |
|---|---|---|---|
| `Common` | `^8.18.0` | — | — |
| `Signalling` | `^8.18.0` | — | — |
| `Extras/SS_Test` | `^8.17.1` | — | — |
| `SFU` | **`^7.5.11`** | `^3.15.5` | — |
| `Extras/mediasoup-sdp-bridge` | — | **`3.15.5`** (exact) | `~3.10.0` |

Two concrete failures followed:

**The production group downgraded `ws` from `^8.18.0` to `^7.5.13`** in `Common` and `Signalling`, levelling everything down to match `SFU`'s legacy `^7`. That's a major downgrade of the WebSocket library the signalling stack is built on — hence `signalling-protocol-test`, `streaming-test-linux/win` and `build-using-local-deps` all failing. It also moved those packages off the root `overrides` pin `"ws@^8": "^8.20.1"`, which is how security pins are enforced in this repo, so the pin silently stopped governing them.

**The development group bumped `mediasoup-client` `~3.10.0` → `~3.23.1`** while leaving the `mediasoup` server at 3.15.5. `Extras/mediasoup-sdp-bridge` bridges the two and stopped type-checking:

```
Type '"http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07"'
  is not assignable to type 'RtpHeaderExtensionUri'.
```

Newer `mediasoup-client` dropped that draft URI from its union type; the older server types still emit it.

Neither was a stale-base problem — rebasing would have changed nothing. All six are closed.

### The fix

```yaml
      - dependency-name: "ws"
      - dependency-name: "mediasoup"
      - dependency-name: "mediasoup-client"
```

These three now need coordinated manual upgrades, which is appropriate: moving `SFU` from ws 7 to 8, or stepping `mediasoup` and `mediasoup-client` together, are deliberate changes with real API surface, not routine bumps. Everything else continues to flow as grouped minor/patch updates.

Worth noting these are `ignore` rules with no `update-types`, so they suppress **all** updates for those three packages, including security ones. That's the intended trade — a grouped security bump to `ws` was actively making things worse — but it means `ws` and `mediasoup` advisories on the release branches now need handling by hand. `overrides` remains the mechanism for that, as with `qs`, `fast-uri` and `browserslist`.

### Separately

While reading the CI logs for these PRs I noticed `actions/setup-node@v4` is still on node20, so #1032–#1035 did **not** finish the Node 20 migration — I only bumped the five actions Dependabot happened to flag. Seven remain on deprecated runtimes (`github-script@v5` is on **node12**, `stale@v8` / `login-action@v2` / `create-issue-from-file@v4` on **node16**, plus `setup-node@v4`, `changesets/action@v1.4.10` and `backport-github-action@v9.5.1` on node20). Following up in a separate PR set before the 23 September cutoff.
