### PR TITLE
ci: bump the remaining actions to node24 runtimes

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.5.1
+        uses: sorenlouv/backport-github-action@v12
         with:
           # A PAT (repo + workflow scope) is required: org policy forbids the
           # default GITHUB_TOKEN from creating PRs, and PRs opened with it also
@@ -30,7 +30,7 @@ jobs:
           # org secret named AUTOMATION_PAT.
           github_token: ${{ secrets.AUTOMATION_PAT }}
           auto_backport_label_prefix: auto-backport-to-
-          add_original_reviewers: true
+          copy_source_pr_reviewers: true
 
       - name: Info log
         if: ${{ success() }}

--- a/.github/workflows/changesets-publish-npm-packages.yml
+++ b/.github/workflows/changesets-publish-npm-packages.yml
@@ -87,7 +87,7 @@ jobs:
         run: echo "node_version=$(cat NODE_VERSION)" >> $GITHUB_OUTPUT
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "${{ steps.get_node_version.outputs.node_version }}"
           registry-url: 'https://registry.npmjs.org'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Create or update release tag
         if: ${{ inputs.dry_run != true }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = 'refs/tags/${{ steps.build-label.outputs.label }}';

--- a/.github/workflows/changesets-update-changelogs.yml
+++ b/.github/workflows/changesets-update-changelogs.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: 'npm'
@@ -34,13 +34,17 @@ jobs:
       # branch's workspace. It runs inside the action's release-branch worktree
       # (after its internal `git reset --hard`) so the rewrites survive.
       - name: Create Release Pull Request
-        uses: changesets/action@v1.4.10
+        uses: changesets/action@v2
         env:
           # Org policy forbids the default GITHUB_TOKEN from creating PRs, so a
           # PAT (repo + workflow scope) is required to open the release PR.
           GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
         with:
-          title: '[Bot] NPM Packages Release ${{ github.ref_name }}'
-          commit: 'Updated NPM changelogs'
-          version: bash .github/scripts/version-with-normalized-suffixes.sh
+          # v2 renamed these inputs, and its `github-token` defaults to the
+          # default GITHUB_TOKEN -- which org policy forbids from creating
+          # PRs -- so the PAT must now be passed explicitly as an input.
+          github-token: ${{ secrets.AUTOMATION_PAT }}
+          pr-title: '[Bot] NPM Packages Release ${{ github.ref_name }}'
+          commit-message: 'Updated NPM changelogs'
+          version-script: bash .github/scripts/version-with-normalized-suffixes.sh
 

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -52,7 +52,7 @@ jobs:
   #     id: get_node_version
   #     run: echo "node_version=$(cat NODE_VERSION)" >> $Env:GITHUB_OUTPUT
   #
-  #   - uses: actions/setup-node@v4
+  #   - uses: actions/setup-node@v7
   #     with:
   #       node-version: ${{ steps.get_node_version.outputs.node_version }}
   #

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -27,7 +27,7 @@ jobs:
       id: get_node_version
       run: echo "node_version=$(cat NODE_VERSION)" >> $GITHUB_OUTPUT
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: "${{ steps.get_node_version.outputs.node_version }}"
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Find existing link checker issue
         id: find-issue
         if: always()
-        uses: actions/github-script@v5
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create or update link checker issue
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
@@ -51,7 +51,7 @@ jobs:
 
       - name: Close existing issue if all links pass
         if: env.lychee_exit_code == 0 && steps.find-issue.outputs.result != ''
-        uses: actions/github-script@v5
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.update({

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -56,7 +56,7 @@ jobs:
       id: get_node_version
       run: echo "node_version=$(cat NODE_VERSION)" >> $Env:GITHUB_OUTPUT
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ steps.get_node_version.outputs.node_version }}
         cache: 'npm'

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -25,7 +25,7 @@ jobs:
           echo "version=${BRANCH_NAME#UE}" >> $GITHUB_OUTPUT
         
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: pixelstreamingunofficial
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Create or update release tag
-        uses: actions/github-script@v5
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = 'refs/tags/signalling-webserver-${{ github.ref_name }}-${{ fromJson(steps.get-package-json.outputs.json).version }}';

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -26,7 +26,7 @@ jobs:
           echo "version=${BRANCH_NAME#UE}" >> $GITHUB_OUTPUT
         
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: pixelstreamingunofficial
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Create or update release tag
-        uses: actions/github-script@v5
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = 'refs/tags/sfu-${{ github.ref_name }}-${{ fromJson(steps.get-package-json.outputs.json).version }}';

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v8
+    - uses: actions/stale@v11
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Issues go stale after 30 days of inactivity. Please comment or re-open the issue if you are still interested in getting this issue fixed.'


### PR DESCRIPTION
Finishes the Node 20 migration on this branch. #1032–#1035 only covered the five actions Dependabot had flagged; **seven others were left on deprecated runtimes**, which I missed and should have caught then.

Node 20 is removed from Actions runners on **23 September 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). After this PR there are **zero** actions on node12/16/20 on this branch — I verified by resolving `runs.using` for every `uses:` reference.

| Action | Was | Runtime | Now | Refs |
|---|---|---|---|---|
| `actions/github-script` | v5 | **node12** | v9 | 5 |
| `actions/stale` | v8 | **node16** | v11 | 1 |
| `docker/login-action` | v2 | **node16** | v4 | 2 |
| `peter-evans/create-issue-from-file` | v4 | **node16** | v6 | 1 |
| `actions/setup-node` | v4 | node20 | v7 | 5 |
| `changesets/action` | v1.4.10 | node20 | v2 | 1 |
| backport action | `sorenlouv/backport-github-action@v9.5.1` | node16/20 | `sorenlouv/backport-github-action@v12` | 1 |

`actions/setup-node` is in every build workflow, `docker/login-action` gates container publishing, and the backport action is the backport bot itself — so none of these are optional.

### Two of them needed input migrations

Five were clean version bumps: I checked every input this branch passes against each target's `action.yml` and all were present and unrenamed. The other two were not:

**`changesets/action` v1 → v2** renamed its entire input surface, and has one trap worth calling out:

| Old | New |
|---|---|
| `title` | `pr-title` |
| `commit` | `commit-message` |
| `version` | `version-script` |

v2 also added a `github-token` input that **defaults to `\${{ github.token }}`**. This workflow currently supplies `AUTOMATION_PAT` via the `GITHUB_TOKEN` env var, because — per the existing comment in the file — org policy forbids the default token from creating PRs. Left alone, v2 would have silently fallen back to the default token and broken the release PR. The PAT is now passed explicitly as `github-token`, with the env var retained for git operations.

**`backport-github-action` v9/v8 → v12** removed `add_original_reviewers`, replaced by `copy_source_pr_reviewers`. Renamed accordingly.


### Verification

Every workflow still parses as valid YAML, and the diff is 24 insertions / 20 deletions across 10 files — one line per reference plus the input renames and the three-line comment explaining the token change. No reformatting.

The one thing CI can't prove here: `changesets-update-changelogs.yml`, `backport.yml`, `stale.yml` and `healthcheck-markdown-links.yml` only fire on release pushes, PR labels or a schedule, so they won't be exercised by this PR's checks. The changesets input migration in particular is the piece I'd want a second pair of eyes on before merge.
