### PR TITLE
[UE5.8] fix(frontend): drop type assertions the newer linter reports as unnecessary

### DIFF
--- a/Frontend/library/src/DataChannel/DataChannelController.ts
+++ b/Frontend/library/src/DataChannel/DataChannelController.ts
@@ -35,7 +35,7 @@ export class DataChannelController {
         this.label = label;
         this.datachannelOptions = datachannelOptions;
         if (datachannelOptions == null) {
-            this.datachannelOptions = {} as RTCDataChannelInit;
+            this.datachannelOptions = {};
             this.datachannelOptions.ordered = true;
         }
 

--- a/Frontend/library/src/Inputs/GamepadController.ts
+++ b/Frontend/library/src/Inputs/GamepadController.ts
@@ -166,14 +166,18 @@ export class GamepadController implements IInputController {
                 controller.id === undefined ? this.controllers.indexOf(controller) : controller.id;
             const currentState = controller.currentState;
             for (let i = 0; i < controller.currentState.buttons.length; i++) {
+                // Typed as GamepadLayout so the comparisons below share an enum type.
+                // Asserting `i as GamepadLayout` inline satisfies no-unsafe-enum-comparison
+                // but trips no-unnecessary-type-assertion; this satisfies both.
+                const buttonIndex: GamepadLayout = i;
                 const currentButton = controller.currentState.buttons[i];
                 const previousButton = controller.prevState.buttons[i];
                 if (currentButton.pressed) {
                     // press
-                    if ((i as GamepadLayout) === GamepadLayout.LeftTrigger) {
+                    if (buttonIndex === GamepadLayout.LeftTrigger) {
                         // UEs left analog has a button index of 5
                         toStreamerHandlers.get('GamepadAnalog')([controllerId, 5, currentButton.value]);
-                    } else if ((i as GamepadLayout) === GamepadLayout.RightTrigger) {
+                    } else if (buttonIndex === GamepadLayout.RightTrigger) {
                         // UEs right analog has a button index of 6
                         toStreamerHandlers.get('GamepadAnalog')([controllerId, 6, currentButton.value]);
                     } else {
@@ -185,10 +189,10 @@ export class GamepadController implements IInputController {
                     }
                 } else if (!currentButton.pressed && previousButton.pressed) {
                     // release
-                    if ((i as GamepadLayout) === GamepadLayout.LeftTrigger) {
+                    if (buttonIndex === GamepadLayout.LeftTrigger) {
                         // UEs left analog has a button index of 5
                         toStreamerHandlers.get('GamepadAnalog')([controllerId, 5, 0]);
-                    } else if ((i as GamepadLayout) === GamepadLayout.RightTrigger) {
+                    } else if (buttonIndex === GamepadLayout.RightTrigger) {
                         // UEs right analog has a button index of 6
                         toStreamerHandlers.get('GamepadAnalog')([controllerId, 6, 0]);
                     } else {

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -175,7 +175,7 @@ export class WebRtcPlayerController {
         this.transport = new WebSocketTransport(config.webSocketProtocols);
         this.protocol = new SignallingProtocol(this.transport);
         this.protocol.addListener(Messages.config.typeName, (msg: BaseMessage) =>
-            this.handleOnConfigMessage(msg as Messages.config)
+            this.handleOnConfigMessage(msg)
         );
         this.protocol.addListener(Messages.ping.typeName, (msg: BaseMessage) =>
             this.handlePingMessage(msg as Messages.ping)


### PR DESCRIPTION
Unblocks the Dependabot dev-group PRs, which fail `build-using-local-deps` on six eslint errors in `Frontend/library`.

### Why lint broke without the config changing

The eslint config is untouched. All six errors are `@typescript-eslint/no-unnecessary-type-assertion`, which is a **type-aware** rule — its results depend on the TypeScript version and the types in scope, not on the config. The dev-group PR bumps `typescript-eslint` **8.57.2 → 8.69.0** (12 minors) and `@types/node` `^22.14.0 → ^22.20.1`, and 8.69 extends the rule to flag assertions whose *contextual* type already accepts the expression, not just ones that are outright no-ops.

So these are pre-existing latent issues that only a newer linter notices. Nothing regressed.

The rule is being precise rather than blanket — worth confirming, since a type-aware rule firing after a version bump can easily be a false positive. Two examples:

- `msg as Messages.config` **is** flagged, but `msg as Messages.ping` on the very next line is not. `Messages.config` has only `type` required (everything else optional) and `BaseMessage` supplies it, so `BaseMessage` is already assignable and the assertion changes nothing. `Messages.ping` has a required field, so its assertion is load-bearing.
- `{} as RTCDataChannelInit` — every property of `RTCDataChannelInit` is optional, so `{}` alone is assignable.

All six are type-level only and erased at runtime, so behaviour is unchanged.

### The gamepad cases needed more than deleting the assertion

Removing `(i as GamepadLayout)` outright trades one error for four others — `@typescript-eslint/no-unsafe-enum-comparison` then fires with *"The two values in this comparison do not have a shared enum type"*, because `i` is a plain `number`. I confirmed this under both 8.57.2 and 8.69.0: neither `(i as GamepadLayout) === X` nor `i === X` is clean. The two rules directly conflict on that expression.

The button index is now a `GamepadLayout`-typed local, which satisfies both:

```ts
const buttonIndex: GamepadLayout = i;
```

It carries a comment explaining why, since it otherwise reads as a redundant variable somebody would inline again.

### Verification

Run in a real checkout, not reasoned about:

| Check | Result |
|---|---|
| `eslint src` in `Frontend/library`, typescript-eslint **8.57.2** (current) | clean |
| `eslint src` in `Frontend/library`, typescript-eslint **8.69.0** (incoming) | clean |
| `tsc --noEmit` on `Frontend/library` | clean |
| `npm run build` (all workspaces) | passes |

Clean under both linter versions, so this can merge on its own ahead of the dependency bump rather than being tied to it.

One pre-existing failure this does **not** address: `npm run lint` at the repo root reports 39 errors in `Extras/JSStreamer` and a failure in `Extras/mediasoup-sdp-bridge`. I verified those are identical on the unmodified branch, so they're untouched by this change. CI's `build-using-local-deps` doesn't reach them because it lints specific workspaces rather than running the root script.
