### PR TITLE
fix(frontend): declare webpack config deps instead of relying on hoisting

### DIFF
--- a/Frontend/implementations/react/package.json
+++ b/Frontend/implementations/react/package.json
@@ -22,7 +22,8 @@
         "ts-loader": "^9.5.2",
         "typescript": "^5.7.3",
         "webpack": "^5.97.1",
-        "webpack-cli": "^6.0.1"
+        "webpack-cli": "^6.0.1",
+        "webpack-merge": "^6.0.1"
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.8": "*",

--- a/Frontend/implementations/typescript/package.json
+++ b/Frontend/implementations/typescript/package.json
@@ -19,9 +19,11 @@
     "devDependencies": {
         "html-loader": "^5.1.0",
         "html-webpack-plugin": "^5.6.3",
+        "terser-webpack-plugin": "^5.6.0",
         "ts-loader": "^9.5.2",
         "webpack": "^5.97.1",
-        "webpack-cli": "^6.0.1"
+        "webpack-cli": "^6.0.1",
+        "webpack-merge": "^6.0.1"
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingfrontend-ue5.8": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,7 +271,8 @@
                 "ts-loader": "^9.5.2",
                 "typescript": "^5.7.3",
                 "webpack": "^5.97.1",
-                "webpack-cli": "^6.0.1"
+                "webpack-cli": "^6.0.1",
+                "webpack-merge": "^6.0.1"
             }
         },
         "Frontend/implementations/typescript": {
@@ -284,9 +285,11 @@
             "devDependencies": {
                 "html-loader": "^5.1.0",
                 "html-webpack-plugin": "^5.6.3",
+                "terser-webpack-plugin": "^5.6.0",
                 "ts-loader": "^9.5.2",
                 "webpack": "^5.97.1",
-                "webpack-cli": "^6.0.1"
+                "webpack-cli": "^6.0.1",
+                "webpack-merge": "^6.0.1"
             }
         },
         "Frontend/library": {


### PR DESCRIPTION
Declares two dependencies that the webpack configs require but nothing lists. Unblocks the `streaming-test-win` failure on the Dependabot dev-group PRs.

### The bug

`Frontend/implementations/typescript/webpack.prod.js:5` does:

```js
const TerserPlugin = require('terser-webpack-plugin');
```

…and **no `package.json` in the repo declares `terser-webpack-plugin`**. It only ever resolved because `webpack` listed it as a dependency and npm hoisted it to the root. **webpack 5.110 dropped it** (minification is an optional peer now), so the moment webpack is bumped past that, the production bundle build fails:

```
[webpack-cli] Error: Cannot find module 'terser-webpack-plugin'
```

Auditing every `require()` in the webpack and jest configs against the owning workspace's manifest turned up the same class of bug for `webpack-merge`, in **both** implementations — currently supplied only by `webpack-cli`, so equally exposed to any `webpack-cli` change.

| Workspace | Added |
|---|---|
| `Frontend/implementations/typescript` | `terser-webpack-plugin` `^5.6.0`, `webpack-merge` `^6.0.1` |
| `Frontend/implementations/react` | `webpack-merge` `^6.0.1` |

Both pinned at the versions already resolving today, so nothing actually changes version — this only makes the dependency explicit. Lockfile regenerated on each branch rather than cherry-picked.

### Verification

I reproduced the CI failure and confirmed the fix end to end, rather than reasoning about it. Starting from this branch plus the dev-group PR's `webpack` `^5.110.3`:

| State | `require.resolve('terser-webpack-plugin')` | Prod bundle build |
|---|---|---|
| With this fix | resolves | **exit 0** |
| With the declaration removed | `MODULE_NOT_FOUND` | **exit 2**, `Cannot find module 'terser-webpack-plugin'` |

That's the identical error CI reports, appearing and disappearing with the one-line declaration — so this is the cause, not a coincidence.

Also confirmed `webpack@5.110.3`'s own manifest no longer lists `terser-webpack-plugin`, which is why the transitive route disappeared.

### Note

This is worth fixing on its own merits regardless of the dependency bump. `streaming-test-linux` currently **passes** while `streaming-test-win` fails on the same code, purely because hoisting happens to place the module differently across platforms — a latent bug that only shows up on one OS is worse than one that fails everywhere.
