### PR TITLE
[UE5.7] test: pin @playwright/test so both suites use the same browser build

### DIFF
--- a/Extras/FrontendTests/package.json
+++ b/Extras/FrontendTests/package.json
@@ -14,7 +14,7 @@
     "author": "Epic Games",
     "license": "MIT",
     "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "1.60.0",
         "@types/node": "^22.14.0",
         "@types/uuid": "^9.0.8"
     },

--- a/Extras/MinimalStreamTester/package.json
+++ b/Extras/MinimalStreamTester/package.json
@@ -13,7 +13,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "1.60.0",
         "@types/node": "^22.14.0",
         "@types/uuid": "^9.0.8"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
                 "uuid": "^14.0.2"
             },
             "devDependencies": {
-                "@playwright/test": "^1.49.1",
+                "@playwright/test": "1.60.0",
                 "@types/node": "^22.14.0",
                 "@types/uuid": "^9.0.8"
             }
@@ -296,7 +296,7 @@
                 "uuid": "^14.0.2"
             },
             "devDependencies": {
-                "@playwright/test": "^1.49.1",
+                "@playwright/test": "1.60.0",
                 "@types/node": "^22.14.0",
                 "@types/uuid": "^9.0.8"
             }


### PR DESCRIPTION
Pins `@playwright/test` so both test suites run the same browser build.

### The inconsistency

`Extras/FrontendTests` builds its own Docker image and runs `npm install` inside it against `^1.49.1` with no lockfile in the image context — so it always resolved to the newest Playwright, and therefore the newest Firefox. `Extras/MinimalStreamTester` runs on the Windows runner and follows the root lockfile, which held Playwright 1.60.0.

Two suites, two different browsers, neither deliberately chosen. That's what let Firefox 155 break each suite separately, weeks apart:

| Suite | Browser it was getting | Symptom |
|---|---|---|
| `Extras/FrontendTests` | newest (155 for days) | pointer-lock semantics changed → `@locked` mouse tests failed |
| `Extras/MinimalStreamTester` | 150.0.2 via lockfile | only broke once a dev-group PR bumped the lockfile to 1.63.0 |

### The pin

Both now pin `1.60.0` exactly (Firefox 150.0.2) — the newest build **both** suites currently pass on. Firefox 155 breaks `MinimalStreamTester`'s stream test, so it isn't a viable common version yet.

Exact rather than a caret range, because the version determines which browser engine gets downloaded — that should be an explicit choice, matching how `typescript-eslint` is pinned exactly in this repo.

### Verification

I ran the full `Extras/FrontendTests` suite in Docker at this pin: **21 passed, 0 failed on Firefox 150.0.2**. Combined with earlier runs, the locked-mouse fix from #1005–#1008 now holds on Firefox **150, 153 and 155** — it is genuinely version-agnostic rather than tuned to one build, which is what makes stepping the pin forward later a safe operation.

`npm ci && npm run build` also verified on this branch.
