### PR TITLE
[UE5.6] test: pin @playwright/test so both suites use the same browser build

### DIFF
--- a/Extras/FrontendTests/package.json
+++ b/Extras/FrontendTests/package.json
@@ -14,7 +14,7 @@
     "author": "Epic Games",
     "license": "MIT",
     "devDependencies": {
-        "@playwright/test": "^1.63.0",
+        "@playwright/test": "1.60.0",
         "@types/node": "^22.20.1",
         "@types/uuid": "^9.0.8"
     },

--- a/Extras/MinimalStreamTester/package.json
+++ b/Extras/MinimalStreamTester/package.json
@@ -13,7 +13,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "@playwright/test": "^1.63.0",
+        "@playwright/test": "1.60.0",
         "@types/node": "^22.20.1",
         "@types/uuid": "^9.0.8"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "uuid": "^14.0.2"
             },
             "devDependencies": {
-                "@playwright/test": "^1.63.0",
+                "@playwright/test": "1.60.0",
                 "@types/node": "^22.20.1",
                 "@types/uuid": "^9.0.8"
             }
@@ -171,20 +171,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "Extras/JSStreamer/node_modules/enhanced-resolve": {
-            "version": "5.24.5",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
-            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "Extras/JSStreamer/node_modules/media-typer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
@@ -256,62 +242,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "Extras/JSStreamer/node_modules/watchpack": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
-            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "Extras/JSStreamer/node_modules/webpack": {
-            "version": "5.110.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
-            "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.8",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
-                "browserslist": "^4.28.1",
-                "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.4",
-                "es-module-lexer": "^2.1.0",
-                "events": "^3.2.0",
-                "graceful-fs": "^4.2.11",
-                "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.7.0",
-                "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.3",
-                "tapable": "^2.3.0",
-                "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.1"
-            },
-            "bin": {
-                "webpack": "bin/webpack.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependenciesMeta": {
-                "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
         "Extras/mediasoup-sdp-bridge": {
             "name": "@epicgames-ps/mediasoup-sdp-bridge",
             "version": "1.0.6",
@@ -341,7 +271,7 @@
                 "mediasoup": "3.15.5",
                 "mediasoup-client": "~3.10.0",
                 "open-cli": "^6.0.1",
-                "prettier": "^2.8.8",
+                "prettier": "~2.8.8",
                 "tsc-watch": "^4.2.8",
                 "typescript": "^5.7.3"
             },
@@ -382,7 +312,7 @@
                 "uuid": "^14.0.2"
             },
             "devDependencies": {
-                "@playwright/test": "^1.63.0",
+                "@playwright/test": "1.60.0",
                 "@types/node": "^22.20.1",
                 "@types/uuid": "^9.0.8"
             }
@@ -443,86 +373,6 @@
                 "webpack-merge": "^6.0.1"
             }
         },
-        "Frontend/implementations/react/node_modules/enhanced-resolve": {
-            "version": "5.24.5",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
-            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "Frontend/implementations/react/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "Frontend/implementations/react/node_modules/watchpack": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
-            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "Frontend/implementations/react/node_modules/webpack": {
-            "version": "5.110.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
-            "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.8",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
-                "browserslist": "^4.28.1",
-                "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.4",
-                "es-module-lexer": "^2.1.0",
-                "events": "^3.2.0",
-                "graceful-fs": "^4.2.11",
-                "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.7.0",
-                "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.3",
-                "tapable": "^2.3.0",
-                "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.1"
-            },
-            "bin": {
-                "webpack": "bin/webpack.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependenciesMeta": {
-                "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
         "Frontend/implementations/typescript": {
             "name": "@epicgames-ps/reference-pixelstreamingfrontend-ue5.6",
             "version": "0.0.1",
@@ -538,86 +388,6 @@
                 "webpack": "^5.110.3",
                 "webpack-cli": "^6.0.1",
                 "webpack-merge": "^6.0.1"
-            }
-        },
-        "Frontend/implementations/typescript/node_modules/enhanced-resolve": {
-            "version": "5.24.5",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
-            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "Frontend/implementations/typescript/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "Frontend/implementations/typescript/node_modules/watchpack": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
-            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "Frontend/implementations/typescript/node_modules/webpack": {
-            "version": "5.110.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
-            "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.8",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
-                "browserslist": "^4.28.1",
-                "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.4",
-                "es-module-lexer": "^2.1.0",
-                "events": "^3.2.0",
-                "graceful-fs": "^4.2.11",
-                "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.7.0",
-                "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.3",
-                "tapable": "^2.3.0",
-                "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.1"
-            },
-            "bin": {
-                "webpack": "bin/webpack.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependenciesMeta": {
-                "webpack-cli": {
-                    "optional": true
-                }
             }
         },
         "Frontend/library": {
@@ -2234,9 +2004,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2315,9 +2085,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2527,9 +2297,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3735,19 +3505,19 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
-            "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.63.0"
+                "playwright": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/@protobuf-ts/plugin": {
@@ -4069,9 +3839,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-            "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+            "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4202,6 +3972,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
@@ -4289,12 +4066,13 @@
             "license": "MIT"
         },
         "node_modules/@types/send": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@types/mime": "^1",
                 "@types/node": "*"
             }
         },
@@ -4906,20 +4684,6 @@
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
-            }
-        },
-        "node_modules/acorn-import-phases": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "peerDependencies": {
-                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -5544,6 +5308,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/body-parser/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
+        },
         "node_modules/bonjour-service": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
@@ -5563,9 +5333,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -6167,9 +5937,9 @@
             }
         },
         "node_modules/color-string/node_modules/color-name": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-            "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+            "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
@@ -6188,9 +5958,9 @@
             }
         },
         "node_modules/color/node_modules/color-name": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-            "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+            "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
@@ -6649,9 +6419,9 @@
             }
         },
         "node_modules/cspell-glob/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7464,12 +7234,11 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.22.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-            "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.3.3"
@@ -7925,9 +7694,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8233,9 +8002,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9064,9 +8833,9 @@
             }
         },
         "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -9305,14 +9074,6 @@
             "peerDependencies": {
                 "tslib": "2"
             }
-        },
-        "node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true
         },
         "node_modules/global-directory": {
             "version": "4.0.1",
@@ -9905,9 +9666,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9942,9 +9703,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+            "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12273,21 +12034,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/loader-runner": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.11.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -12364,9 +12110,9 @@
             }
         },
         "node_modules/log-update/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12638,16 +12384,16 @@
             }
         },
         "node_modules/mediasoup-client/node_modules/awaitqueue": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.0.tgz",
-            "integrity": "sha512-zLxDhzQbzHmOyvxi7g3OlfR7jLrcmElStPxfLPpJkrFSDm71RSrY/MvsDA8Btlx8X1nOHUzGhQvc6bdUjL2f2w==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.1.tgz",
+            "integrity": "sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debug": "^4.4.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -12655,16 +12401,16 @@
             }
         },
         "node_modules/mediasoup-client/node_modules/h264-profile-level-id": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.2.tgz",
-            "integrity": "sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+            "integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debug": "^4.4.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -12685,15 +12431,15 @@
             }
         },
         "node_modules/mediasoup/node_modules/h264-profile-level-id": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.2.tgz",
-            "integrity": "sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+            "integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
             "license": "ISC",
             "dependencies": {
                 "debug": "^4.4.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -12929,12 +12675,12 @@
             "link": true
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -13040,13 +12786,6 @@
                 }
             }
         },
-        "node_modules/minimizer-webpack-plugin/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -13060,17 +12799,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
@@ -13087,25 +12815,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/terser": {
-            "version": "5.51.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
-            "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.15.0",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/minipass": {
@@ -13726,9 +13435,9 @@
             }
         },
         "node_modules/openapi-framework/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -14156,9 +13865,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -14292,32 +14001,35 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
-            "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.63.0"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
-            "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             }
         },
         "node_modules/possible-typed-array-names": {
@@ -14367,9 +14079,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -14778,9 +14490,9 @@
             }
         },
         "node_modules/read-yaml-file/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16132,9 +15844,9 @@
             }
         },
         "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16448,9 +16160,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-            "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+            "version": "5.51.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+            "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -16670,9 +16382,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17579,14 +17291,12 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             },
             "engines": {
@@ -17619,12 +17329,11 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.107.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-            "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+            "version": "5.110.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
+            "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
@@ -17632,23 +17341,19 @@
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
                 "acorn": "^8.16.0",
-                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.22.0",
+                "enhanced-resolve": "^5.24.4",
                 "es-module-lexer": "^2.1.0",
-                "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "loader-runner": "^4.3.2",
                 "mime-db": "^1.54.0",
+                "minimizer-webpack-plugin": "^5.7.0",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
-                "terser-webpack-plugin": "^5.5.0",
-                "watchpack": "^2.5.1",
-                "webpack-sources": "^3.5.0"
+                "watchpack": "^2.5.2",
+                "webpack-sources": "^3.5.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -17848,9 +17553,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.8",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-            "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17898,13 +17603,26 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+            "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/is-plain-obj": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/webpack-dev-server/node_modules/open": {
@@ -17961,39 +17679,12 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/webpack/node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/webpack/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/webpack/node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -18300,9 +17991,9 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18362,9 +18053,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -18577,9 +18268,9 @@
             }
         },
         "SFU/node_modules/ws": {
-            "version": "7.5.11",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-            "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"


### PR DESCRIPTION
Pins `@playwright/test` so both test suites run the same browser build.

### The inconsistency

`Extras/FrontendTests` builds its own Docker image and runs `npm install` inside it against `^1.49.1` with no lockfile in the image context — so it always resolved to the newest Playwright, and therefore the newest Firefox. `Extras/MinimalStreamTester` runs on the Windows runner and follows the root lockfile, which held Playwright 1.60.0.

Two suites, two different browsers, neither deliberately chosen. That's what let Firefox 155 break each suite separately, weeks apart:

| Suite | Browser it was getting | Symptom |
|---|---|---|
| `Extras/FrontendTests` | newest (155 for days) | pointer-lock semantics changed → `@locked` mouse tests failed |
| `Extras/MinimalStreamTester` | 150.0.2 via lockfile | only broke once a dev-group PR bumped the lockfile to 1.63.0 |

### The pin

Both now pin `1.60.0` exactly (Firefox 150.0.2) — the newest build **both** suites currently pass on. Firefox 155 breaks `MinimalStreamTester`'s stream test, so it isn't a viable common version yet.

Exact rather than a caret range, because the version determines which browser engine gets downloaded — that should be an explicit choice, matching how `typescript-eslint` is pinned exactly in this repo.

### Verification

I ran the full `Extras/FrontendTests` suite in Docker at this pin: **21 passed, 0 failed on Firefox 150.0.2**. Combined with earlier runs, the locked-mouse fix from #1005–#1008 now holds on Firefox **150, 153 and 155** — it is genuinely version-agnostic rather than tuned to one build, which is what makes stepping the pin forward later a safe operation.

`npm ci && npm run build` also verified on this branch.

### Note specific to UE5.6

This branch had **already taken Playwright 1.63.0** via #1042, so this is a downgrade rather than a no-op — hence the larger lockfile diff (the other branches were already resolving 1.60.0, so their diff is 4 lines).

Worth flagging why that went unnoticed: UE5.6's `streaming-test-linux` and `streaming-test-win` checks report `skipping`, so nothing ever exercised Firefox 155 here. The branch has been sitting on the browser build that fails `MinimalStreamTester` on UE5.7 and UE5.8, unverified. That check-skipping is worth looking at separately — it means UE5.6 merges land without the streaming suites ever running.

I verified `npm ci && npm run build` locally on this branch instead. The only failure is `Frontend/implementations/react`, which is the pre-existing `.tsx`/JSX loader issue already present on this branch and unrelated to this change.
