### PR TITLE
ci(dependabot): ignore @playwright/test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,13 @@ updates:
       - dependency-name: "ws"
       - dependency-name: "mediasoup"
       - dependency-name: "mediasoup-client"
+      # @playwright/test pulls a specific browser build with it, so a routine
+      # dev bump is really a browser engine upgrade. Firefox 155 (Playwright
+      # 1.63) broke two unrelated suites: pointer-lock semantics changed under
+      # Extras/FrontendTests, and Extras/MinimalStreamTester stopped receiving
+      # a stream from the UE streamer entirely. Upgrade this deliberately,
+      # alongside whatever test work the new browser needs.
+      - dependency-name: "@playwright/test"
     groups:
       npm-development:
         dependency-type: development
@@ -88,6 +95,13 @@ updates:
       - dependency-name: "ws"
       - dependency-name: "mediasoup"
       - dependency-name: "mediasoup-client"
+      # @playwright/test pulls a specific browser build with it, so a routine
+      # dev bump is really a browser engine upgrade. Firefox 155 (Playwright
+      # 1.63) broke two unrelated suites: pointer-lock semantics changed under
+      # Extras/FrontendTests, and Extras/MinimalStreamTester stopped receiving
+      # a stream from the UE streamer entirely. Upgrade this deliberately,
+      # alongside whatever test work the new browser needs.
+      - dependency-name: "@playwright/test"
     groups:
       npm-development:
         dependency-type: development
@@ -121,6 +135,13 @@ updates:
       - dependency-name: "ws"
       - dependency-name: "mediasoup"
       - dependency-name: "mediasoup-client"
+      # @playwright/test pulls a specific browser build with it, so a routine
+      # dev bump is really a browser engine upgrade. Firefox 155 (Playwright
+      # 1.63) broke two unrelated suites: pointer-lock semantics changed under
+      # Extras/FrontendTests, and Extras/MinimalStreamTester stopped receiving
+      # a stream from the UE streamer entirely. Upgrade this deliberately,
+      # alongside whatever test work the new browser needs.
+      - dependency-name: "@playwright/test"
     groups:
       npm-development:
         dependency-type: development


### PR DESCRIPTION
Adds `@playwright/test` to the `ignore` lists, alongside `ws`, `mediasoup` and `mediasoup-client` from #1036.

### Why

The package downloads a specific browser build with it, so what looks like a dev-dependency bump is really a browser engine upgrade. Firefox 155 arrived this way and has now broken **two unrelated suites**:

| Suite | Failure |
|---|---|
| `Extras/FrontendTests` | Firefox 155 stopped re-anchoring the cursor under pointer lock, so the `@locked` mouse tests failed (fixed in #1005–#1008) |
| `Extras/MinimalStreamTester` | the stream never starts at all — `playStream` never fires, 120 s timeout, three retries, Chrome passing throughout |

The second is why #1054 and #1041 fail: both bump `@playwright/test` 1.60.0 → 1.63.0, which is Firefox 150.0.2 → 155.0. Rebasing can't help — it's the PR's own dependency change.

A browser upgrade needs to be paired with whatever test work the new engine requires, which is not something a grouped bump can carry.

### What this doesn't do

It doesn't resolve the underlying Firefox 155 problem, and that one may not be only a test issue. `Extras/FrontendTests` passes on Firefox 155 against the JS mock streamer, but `MinimalStreamTester` fails against a real UE streamer on Windows with VP8 and software rendering. If that isn't environment-specific, it affects real users on Firefox 155 — so this suppresses the noisy symptom, not the risk.

`investigate/firefox155-vp8` reproduces it with a vp8/h264 matrix and browser-side diagnostics to narrow that down. #1055–#1058 separately pin both suites to 1.60.0 so the two aren't silently on different browsers.

### Trade-off

Like the existing entries this is an unqualified `ignore`, so it suppresses security updates for `@playwright/test` too. That's acceptable for a dev-only test dependency, but it does mean stepping the version forward is now a deliberate manual act — which is the point.
