### PR TITLE
ci: capture streaming diagnostics when the test actually fails

### DIFF
--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -32,10 +32,12 @@ jobs:
         up-flags: "--build --abort-on-container-exit --exit-code-from tester"
 
     - name: Get short sha
+      if: always()
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       
     - name: Upload results
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: Results-${{ steps.vars.outputs.sha_short }}-Linux

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -123,6 +123,12 @@ jobs:
     - name: Wait for streamer to come up
       run: curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/streamers/DefaultStreamer
 
+    - name: Test if we can stream
+      working-directory: Extras\MinimalStreamTester
+      run: |
+        $Env:PIXELSTREAMING_URL = 'http://localhost:999'
+        npx playwright test
+
     - name: Output signalling logs
       if: always()
       working-directory: SignallingWebServer
@@ -133,17 +139,13 @@ jobs:
       working-directory: Streamer
       run: ls ".\Minimal\" && Test-Path ".\Minimal\Saved\Logs\Minimal.log" && cat ".\Minimal\Saved\Logs\Minimal.log"
 
-    - name: Test if we can stream
-      working-directory: Extras\MinimalStreamTester
-      run: |
-        $Env:PIXELSTREAMING_URL = 'http://localhost:999'
-        npx playwright test
-
     - name: Get short sha
+      if: always()
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $Env:GITHUB_OUTPUT
       
     - name: Upload results
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: Results-${{ steps.vars.outputs.sha_short }}-Win


### PR DESCRIPTION
Fixes two diagnostic gaps that made the Firefox stream failures impossible to debug from CI.

### 1. Log dumps ran before the thing they were meant to diagnose

`healthcheck-streaming.yml` had:

```yaml
    - name: Output signalling logs
      if: always()
      ...
    - name: Output streamer logs
      if: always()
      ...
    - name: Test if we can stream
```

The `if: always()` says these were meant to capture state after a failure, but they sit **above** the test step, so they only ever printed pre-test state. When `MinimalStreamTester` timed out waiting for a stream on Firefox, the logs in the run contained nothing about the browser session at all — the signalling log was dumped minutes before the test connected. Moved below the test step, where `if: always()` does what it was written to do.

### 2. Playwright reports were discarded on failure

`Upload results` had no `if: always()` in either healthcheck, so the `playwright-report` directory — which holds the `trace.zip` for each failed test — was only uploaded when everything passed. Exactly inverted: the traces matter when a test fails.

Added `if: always()` to the upload in both `healthcheck-streaming.yml` and `healthcheck-frontend.yml`, and to the `Get short sha` step they depend on, so the artifact keeps its sha in the name rather than becoming `Results--Win` on the failure path.

### Why now

Both gaps cost real debugging time this week. The `@locked` mouse failures had traces referenced in the log (`npx playwright show-trace test-results\...\trace.zip`) that were never uploaded anywhere, and the stream timeout produced no signalling or streamer output covering the failing session. Neither failure could be diagnosed from CI output alone — both needed local reproduction.

7 insertions, 6 deletions, no behavioural change to what the tests do.
