### PR TITLE
[DO NOT MERGE] investigate: Firefox 155 stream failure (vp8 vs h264)

### DIFF
--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -32,10 +32,12 @@ jobs:
         up-flags: "--build --abort-on-container-exit --exit-code-from tester"
 
     - name: Get short sha
+      if: always()
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       
     - name: Upload results
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: Results-${{ steps.vars.outputs.sha_short }}-Linux

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -123,6 +123,12 @@ jobs:
     - name: Wait for streamer to come up
       run: curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/streamers/DefaultStreamer
 
+    - name: Test if we can stream
+      working-directory: Extras\MinimalStreamTester
+      run: |
+        $Env:PIXELSTREAMING_URL = 'http://localhost:999'
+        npx playwright test
+
     - name: Output signalling logs
       if: always()
       working-directory: SignallingWebServer
@@ -133,17 +139,13 @@ jobs:
       working-directory: Streamer
       run: ls ".\Minimal\" && Test-Path ".\Minimal\Saved\Logs\Minimal.log" && cat ".\Minimal\Saved\Logs\Minimal.log"
 
-    - name: Test if we can stream
-      working-directory: Extras\MinimalStreamTester
-      run: |
-        $Env:PIXELSTREAMING_URL = 'http://localhost:999'
-        npx playwright test
-
     - name: Get short sha
+      if: always()
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $Env:GITHUB_OUTPUT
       
     - name: Upload results
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: Results-${{ steps.vars.outputs.sha_short }}-Win

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -113,10 +113,21 @@ jobs:
         npx playwright install --with-deps
         npx playwright install chrome
 
+    # start.sh/start.bat inject a default STUN server (platform_scripts/bash/
+    # common.sh), but this job runs `npm run start` directly and so skips that,
+    # leaving peer_options empty. With only host candidates, Firefox >=155 fails
+    # ICE and the stream never starts. Written to a file rather than passed
+    # inline to avoid quoting JSON through PowerShell, npm and node.
+    - name: Write peer options
+      run: |
+        $json = '{"iceServers":[{"urls":["stun:stun.l.google.com:19302"]}]}'
+        [System.IO.File]::WriteAllText("${{ github.workspace }}\ci-peer-options.json", $json)
+        Get-Content "${{ github.workspace }}\ci-peer-options.json"
+
     - name: Run Signalling
       working-directory: SignallingWebServer
       # triple hyphen for npm script running issues. With double the arguments get mangled
-      run: Start-Process powershell.exe -ArgumentList "npm","run","start","---","--rest_api","--player_port 999","--http_root ${{ github.workspace }}\www"
+      run: Start-Process powershell.exe -ArgumentList "npm","run","start","---","--rest_api","--player_port 999","--http_root ${{ github.workspace }}\www","--peer_options_file ${{ github.workspace }}\ci-peer-options.json"
 
     - name: Run Streamer
       working-directory: Streamer

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -48,6 +48,12 @@ jobs:
   streaming-test-win:
     if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: windows-latest
+    # INVESTIGATION ONLY: matrix added to isolate whether the Firefox 155
+    # stream failure is VP8-specific. Not for merge.
+    strategy:
+      fail-fast: false
+      matrix:
+        codec: [vp8, h264]
     steps:
     - name: Checkout source code
       uses: actions/checkout@v7
@@ -114,7 +120,7 @@ jobs:
 
     - name: Run Streamer
       working-directory: Streamer
-      run: Start-Process ".\Minimal\Binaries\Win64\Minimal-Cmd.exe" -ArgumentList "-warp","-dx12","-windowed","-resx=1920","-resy=720","-PixelStreamingURL=ws://localhost:8888","-RenderOffScreen","-AllowSoftwareRendering","-PixelStreamingEncoderCodec=vp8", "-Log=Minimal.log"
+      run: Start-Process ".\Minimal\Binaries\Win64\Minimal-Cmd.exe" -ArgumentList "-warp","-dx12","-windowed","-resx=1920","-resy=720","-PixelStreamingURL=ws://localhost:8888","-RenderOffScreen","-AllowSoftwareRendering","-PixelStreamingEncoderCodec=${{ matrix.codec }}", "-Log=Minimal.log"
 
     - name: Wait for signalling to come up
       run: curl --fail-with-body --retry-all-errors --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
@@ -148,5 +154,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: Results-${{ steps.vars.outputs.sha_short }}-Win
+        name: Results-${{ steps.vars.outputs.sha_short }}-Win-${{ matrix.codec }}
         path: Extras\MinimalStreamTester\playwright-report

--- a/Extras/FrontendTests/package.json
+++ b/Extras/FrontendTests/package.json
@@ -14,7 +14,7 @@
     "author": "Epic Games",
     "license": "MIT",
     "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "1.63.0",
         "@types/node": "^22.14.0",
         "@types/uuid": "^9.0.8"
     },

--- a/Extras/MinimalStreamTester/package.json
+++ b/Extras/MinimalStreamTester/package.json
@@ -13,7 +13,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "1.63.0",
         "@types/node": "^22.14.0",
         "@types/uuid": "^9.0.8"
     },

--- a/Extras/MinimalStreamTester/playwright.config.ts
+++ b/Extras/MinimalStreamTester/playwright.config.ts
@@ -40,7 +40,15 @@ export default defineConfig({
 
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: {
+        ...devices['Desktop Firefox'],
+        launchOptions: {
+          // Firefox hides host candidates behind mDNS .local names by default.
+          // The CI runner cannot resolve them, so ICE finds no working pair for
+          // what is a same-machine connection. Real IPs are fine in a test browser.
+          firefoxUserPrefs: { 'media.peerconnection.ice.obfuscate_host_addresses': false }
+        }
+      },
     },
 
     // {

--- a/Extras/MinimalStreamTester/tests/stream_test.spec.ts
+++ b/Extras/MinimalStreamTester/tests/stream_test.spec.ts
@@ -25,10 +25,31 @@ test('Test default stream.', async ({ page }, testinfo) => {
     // set a long timeout to allow for slow software rendering
     test.setTimeout(2 * 60 * 1000);
 
+    // INVESTIGATION ONLY: surface browser-side errors so a stream that never
+    // starts leaves something diagnosable behind.
+    page.on('console', msg => console.log(`[browser:${msg.type()}] ${msg.text()}`));
+    page.on('pageerror', err => console.log(`[pageerror] ${err.message}`));
+
     await page.goto("/?StreamerId=DefaultStreamer");
 
     // wait until we get a stream
-    await startAndWaitForVideo(page);
+    try {
+        await startAndWaitForVideo(page);
+    } catch (e) {
+        const diag = await page.evaluate(() => {
+            const ps = (window as any).pixelStreaming;
+            const pc = ps?.webRtcController?.peerConnectionController?.peerConnection;
+            return {
+                signalingState: pc?.signalingState,
+                iceConnectionState: pc?.iceConnectionState,
+                connectionState: pc?.connectionState,
+                remoteSdp: pc?.remoteDescription?.sdp,
+                localSdp: pc?.localDescription?.sdp
+            };
+        }).catch(() => null);
+        console.log('[diag] peer connection:', JSON.stringify(diag, null, 2));
+        throw e;
+    }
 
     // let the stream run for a small duration
     await delay(15000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
                 "uuid": "^14.0.2"
             },
             "devDependencies": {
-                "@playwright/test": "^1.49.1",
+                "@playwright/test": "1.63.0",
                 "@types/node": "^22.14.0",
                 "@types/uuid": "^9.0.8"
             }
@@ -200,7 +200,7 @@
                 "uuid": "^14.0.2"
             },
             "devDependencies": {
-                "@playwright/test": "^1.49.1",
+                "@playwright/test": "1.63.0",
                 "@types/node": "^22.14.0",
                 "@types/uuid": "^9.0.8"
             }
@@ -2252,9 +2252,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2481,9 +2481,9 @@
             }
         },
         "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
-            "version": "0.34.49",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-            "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+            "version": "0.34.52",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+            "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
             "dev": true,
             "license": "MIT"
         },
@@ -2582,9 +2582,9 @@
             }
         },
         "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3738,19 +3738,19 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+            "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.60.0"
+                "playwright": "1.63.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@protobuf-ts/plugin": {
@@ -3865,9 +3865,9 @@
             "license": "MIT"
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.10",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+            "version": "0.27.12",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+            "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
             "dev": true,
             "license": "MIT"
         },
@@ -4200,9 +4200,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.19.19",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-            "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -4392,9 +4392,9 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+            "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4574,13 +4574,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -6123,9 +6123,9 @@
             }
         },
         "node_modules/color-string/node_modules/color-name": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-            "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+            "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
@@ -6144,9 +6144,9 @@
             }
         },
         "node_modules/color/node_modules/color-name": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-            "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+            "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
@@ -6431,9 +6431,9 @@
             }
         },
         "node_modules/copy-webpack-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+            "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6627,9 +6627,9 @@
             }
         },
         "node_modules/cspell-glob/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6982,9 +6982,9 @@
             }
         },
         "node_modules/default-browser": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8921,12 +8921,12 @@
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -9486,9 +9486,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10845,9 +10845,9 @@
             }
         },
         "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-            "version": "0.34.49",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-            "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+            "version": "0.34.52",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+            "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
             "dev": true,
             "license": "MIT"
         },
@@ -10946,9 +10946,9 @@
             }
         },
         "node_modules/jest-environment-jsdom/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12111,9 +12111,9 @@
             }
         },
         "node_modules/log-update/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12389,16 +12389,16 @@
             }
         },
         "node_modules/mediasoup-client/node_modules/awaitqueue": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.0.tgz",
-            "integrity": "sha512-zLxDhzQbzHmOyvxi7g3OlfR7jLrcmElStPxfLPpJkrFSDm71RSrY/MvsDA8Btlx8X1nOHUzGhQvc6bdUjL2f2w==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.1.tgz",
+            "integrity": "sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debug": "^4.4.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -12406,16 +12406,16 @@
             }
         },
         "node_modules/mediasoup-client/node_modules/h264-profile-level-id": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.2.tgz",
-            "integrity": "sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+            "integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debug": "^4.4.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -12436,15 +12436,15 @@
             }
         },
         "node_modules/mediasoup/node_modules/h264-profile-level-id": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.2.tgz",
-            "integrity": "sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+            "integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
             "license": "ISC",
             "dependencies": {
                 "debug": "^4.4.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -12953,13 +12953,13 @@
             }
         },
         "node_modules/nodemon/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -13359,9 +13359,9 @@
             }
         },
         "node_modules/openapi-framework/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -13787,9 +13787,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -13917,50 +13917,32 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+            "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.60.0"
+                "playwright-core": "1.63.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
+                "node": ">=20"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+            "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/playwright/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+                "node": ">=20"
             }
         },
         "node_modules/possible-typed-array-names": {
@@ -13974,9 +13956,9 @@
             }
         },
         "node_modules/powershell-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+            "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14023,9 +14005,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -14418,9 +14400,9 @@
             }
         },
         "node_modules/read-yaml-file/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15024,9 +15006,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -15662,9 +15644,9 @@
             }
         },
         "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16162,13 +16144,13 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -16256,9 +16238,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16884,13 +16866,13 @@
             }
         },
         "node_modules/typedoc/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -17474,9 +17456,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+            "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17484,18 +17466,18 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/open": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+            "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.4.0",
+                "default-browser": "^5.5.1",
                 "define-lazy-prop": "^3.0.0",
                 "is-in-ssh": "^1.0.0",
                 "is-inside-container": "^1.0.0",
-                "powershell-utils": "^0.1.0",
-                "wsl-utils": "^0.3.0"
+                "powershell-utils": "^0.2.1",
+                "wsl-utils": "^1.0.0"
             },
             "engines": {
                 "node": ">=20"
@@ -17505,9 +17487,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17887,9 +17869,9 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17956,9 +17938,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -17977,9 +17959,9 @@
             }
         },
         "node_modules/wsl-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+            "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18004,6 +17986,19 @@
             },
             "engines": {
                 "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -18172,9 +18167,9 @@
             }
         },
         "SFU/node_modules/ws": {
-            "version": "7.5.11",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-            "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"


### PR DESCRIPTION
**Draft, not for merge.** Exists to gather data on why `Extras/MinimalStreamTester` stops receiving a stream on Firefox 155, which is what fails #1054 and #1041.

What it does:

- Pins `@playwright/test` to **1.63.0** (Firefox 155.0) to reproduce the failure.
- Adds a `vp8` / `h264` streamer matrix, to establish whether it's codec-specific. The job currently hardcodes `-PixelStreamingEncoderCodec=vp8`.
- Captures browser `console` and `pageerror` output from the page.
- On timeout, dumps `signalingState`, `iceConnectionState`, `connectionState` and both SDPs, so we can see how far negotiation got.
- Carries the diagnostic fixes from #1060 so the signalling/streamer logs and Playwright traces actually survive the failure.

Expected outcome — one of:

| Result | Reading |
|---|---|
| both legs fail | Firefox 155 can't play the UE stream at all; likely a real product regression |
| `vp8` fails, `h264` passes | VP8-specific negotiation or decode issue |
| both pass | environment-specific, and the earlier failures were flake or ordering |

Close once the question is answered.