### PR TITLE
[UE5.7] ci: give the windows streaming test a STUN server

### DIFF
--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -107,10 +107,21 @@ jobs:
         npx playwright install --with-deps
         npx playwright install chrome
 
+    # start.sh/start.bat inject a default STUN server (platform_scripts/bash/
+    # common.sh), but this job runs `npm run start` directly and so skips that,
+    # leaving peer_options empty. With only host candidates, Firefox >=155 fails
+    # ICE and the stream never starts. Written to a file rather than passed
+    # inline to avoid quoting JSON through PowerShell, npm and node.
+    - name: Write peer options
+      run: |
+        $json = '{"iceServers":[{"urls":["stun:stun.l.google.com:19302"]}]}'
+        [System.IO.File]::WriteAllText("${{ github.workspace }}\ci-peer-options.json", $json)
+        Get-Content "${{ github.workspace }}\ci-peer-options.json"
+
     - name: Run Signalling
       working-directory: SignallingWebServer
       # triple hyphen for npm script running issues. With double the arguments get mangled
-      run: Start-Process powershell.exe -ArgumentList "npm","run","start","---","--rest_api","--player_port 999","--http_root ${{ github.workspace }}\www"
+      run: Start-Process powershell.exe -ArgumentList "npm","run","start","---","--rest_api","--player_port 999","--http_root ${{ github.workspace }}\www","--peer_options_file ${{ github.workspace }}\ci-peer-options.json"
 
     - name: Run Streamer
       working-directory: Streamer


### PR DESCRIPTION
Gives the Windows streaming healthcheck a STUN server, which it has never had.

### The gap

`SignallingWebServer/config.json` ships `peer_options: ""`, and the launch scripts are what normally fill it — `platform_scripts/bash/common.sh:328-330` defaults `STUN_SERVER="stun.l.google.com:19302"`, and `start.sh` turns that into:

```
--peer_options='{"iceServers":[{"urls":["stun:stun.l.google.com:19302"]}]}'
```

But this job starts the server directly, bypassing all of that:

```yaml
run: Start-Process powershell.exe -ArgumentList "npm","run","start","---","--rest_api",...
```

So the browser has only host candidates to work with. That happened to be survivable and so went unnoticed.

### What it broke

Firefox 150.0.2 tolerated host-candidates-only on the GitHub Windows runner. **Firefox 155.0 does not** — it fails ICE outright:

```
[browser:error] "WebRTC: ICE failed, add a STUN server and see about:webrtc for more details"
[browser:error] [Error] - Protocol timeout
```

That is what fails #1054 and #1041, both of which bump `@playwright/test` 1.60.0 → 1.63.0 (Firefox 150.0.2 → 155.0).

I confirmed it is not codec-specific by running a `vp8` / `h264` matrix on #1061 — **both legs failed identically**, with the same ICE error. It is connectivity, not encoding.

The control case: `Extras/FrontendTests` **passes** on Firefox 155, because it starts signalling through the Dockerfile `ENTRYPOINT` → `start.sh`, and so gets the default STUN server. Its signalling logs show `iceServers` populated.

### The fix

Supplies the same JSON the launch scripts would, via `--peer_options_file` rather than inline — passing a JSON string through `Start-Process` → PowerShell → npm → node is exactly the quoting problem that input exists to avoid, and the file is echoed back into the log so its contents are visible in the run.

### Scope

This is a CI configuration fix, not a product change. Users who launch via `start.sh` / `start.bat` — the documented path — already get a STUN server and were never affected by this.

Follow-on: with ICE working, Firefox 155 should be viable, so the `@playwright/test` pin in #1055–#1058 can be stepped forward deliberately rather than held at 1.60.0 indefinitely.
