### PR TITLE
[UE5.7] fix(ci): pin changesets/action to v1.9.0, not v2

### DIFF
--- a/.github/workflows/changesets-update-changelogs.yml
+++ b/.github/workflows/changesets-update-changelogs.yml
@@ -34,17 +34,19 @@ jobs:
       # branch's workspace. It runs inside the action's release-branch worktree
       # (after its internal `git reset --hard`) so the rewrites survive.
       - name: Create Release Pull Request
-        uses: changesets/action@v2
+        # Stay on v1: changesets/action v2 requires Changesets CLI v3 and this
+        # repo is on @changesets/cli 2.x. v1.9.0 still runs on node24, so the
+        # Node 20 removal is covered without forcing a CLI major.
+        uses: changesets/action@v1.9.0
         env:
           # Org policy forbids the default GITHUB_TOKEN from creating PRs, so a
           # PAT (repo + workflow scope) is required to open the release PR.
           GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
         with:
-          # v2 renamed these inputs, and its `github-token` defaults to the
-          # default GITHUB_TOKEN -- which org policy forbids from creating
-          # PRs -- so the PAT must now be passed explicitly as an input.
+          # github-token defaults to the default GITHUB_TOKEN, which org policy
+          # forbids from creating PRs, so pass the PAT explicitly.
           github-token: ${{ secrets.AUTOMATION_PAT }}
-          pr-title: '[Bot] NPM Packages Release ${{ github.ref_name }}'
-          commit-message: 'Updated NPM changelogs'
-          version-script: bash .github/scripts/version-with-normalized-suffixes.sh
+          title: '[Bot] NPM Packages Release ${{ github.ref_name }}'
+          commit: 'Updated NPM changelogs'
+          version: bash .github/scripts/version-with-normalized-suffixes.sh
 


### PR DESCRIPTION
Fixes the release workflow, which I broke in #1037–#1040.

### What happened

Those PRs bumped `changesets/action` v1.4.10 → v2 as part of getting every action onto a node24 runtime before the 23 September Node 20 removal. I migrated the renamed inputs (`title` → `pr-title`, `commit` → `commit-message`, `version` → `version-script`) and passed `github-token` explicitly to work around the org policy on the default token — but I only checked the action's *input* surface, not its runtime requirements. v2 refuses to start:

```
This version of the Changesets action is designed to work with Changesets CLI v3.
Changesets CLI v2 is not supported; use Changesets action v1 instead
```

This repo is on `@changesets/cli` **2.29.7**, so `Release / Create Release Pull Request` fails immediately on every release branch.

### The fix

`changesets/action@v1.9.0` rather than reverting to v1.4.10:

| | v1.4.10 | **v1.9.0** | v2 |
|---|---|---|---|
| Runtime | node20 | **node24** | node24 |
| Changesets CLI | v2 | **v2** | v3 only |
| Input names | `title`/`commit`/`version` | **same** | renamed |

v1.9.0 is the newest v1.x and moved to node24 in v1.6.0, so the Node 20 deadline stays covered without dragging in a Changesets CLI major. Inputs revert to their original names.

One thing kept from the v2 attempt: `github-token` passed explicitly. v1.4.10 had no such input and read the `GITHUB_TOKEN` env var, but v1.7.0+ added one that **defaults to `${{ github.token }}`** — the default token org policy forbids from creating PRs. Leaving it implicit would reintroduce the same failure by a different route. The env var is retained for git operations.

I re-audited every `uses:` reference on this branch after the change: **no action is left on node12/16/20**.

### Note

Moving to `changesets/action@v2` remains an option later, but it's a Changesets CLI v2 → v3 upgrade, which touches `.changeset/config.json` and the release flow. That deserves its own change, not a runtime bump — and given `version:` here runs a custom suffix-normalising script, it needs testing against a real release PR.

CI on this PR won't exercise the fix: `changesets-update-changelogs.yml` triggers on push to `UE*` with `**/package.json` changes, so it only runs after merge on a release branch.
