### PR TITLE
[UE5.7] fix(frontend): stop mirroring quality settings into the legacy compat QP settings (#985)

### DIFF
--- a/.changeset/encoder-quality-compat-ratchet.md
+++ b/.changeset/encoder-quality-compat-ratchet.md
@@ -1,0 +1,5 @@
+---
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.8": patch
+---
+
+Stop the streamer's encoder quality bounds drifting looser on every connect. `EncoderSettings.MinQuality`/`MaxQuality` from `initialSettings` were mirrored into the legacy `CompatQualityMin`/`CompatQualityMax` settings, whose listeners convert quality back to QP in floating point and send it as `Encoder.MinQP`/`Encoder.MaxQP`. A `MaxQuality` of 70 becomes `15.300000000000004`, which the streamer parses with an integer parse (flooring it to 15) and converts back by rounding (`100 * (1 - 15/51)` = 70.588 -> 71). Flooring one way and rounding the other is not the identity, and `initialSettings` is sent per player, so an application configured for 10/70 was running at 12/71 after one viewer, 14/73 after two, and eventually 25/76 — with the raised lower bound also taking away the encoder's room to drop quality under congestion. The mirror is removed: the streamer already applies `Encoder.MinQuality`/`Encoder.MaxQuality` verbatim, so nothing is lost, and the QP path is left in place for applications that send `MinQP`/`MaxQP` themselves.

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
@@ -519,6 +519,34 @@ describe('PixelStreaming', () => {
         expect(rtcPeerConnectionSpyFunctions.sendDataSpy).toHaveBeenCalled();
     });
 
+    it('should not mirror the streamer\'s quality settings into the legacy compat QP settings', () => {
+        mockHTMLMediaElement({ ableToPlay: true, readyState: 2 });
+
+        const config = new Config({ initialSettings: {ss: mockSignallingUrl}});
+        const pixelStreaming = new PixelStreaming(config);
+        pixelStreaming.connect();
+
+        establishMockedPixelStreamingConnection();
+
+        pixelStreaming.play();
+
+        const initialSettings = new InitialSettings();
+        initialSettings.EncoderSettings.MinQuality = 10;
+        initialSettings.EncoderSettings.MaxQuality = 70;
+        pixelStreaming._onInitialSettings(initialSettings);
+
+        // The quality settings themselves take the streamer's values.
+        expect(config.getNumericSettingValue(NumericParameters.MinQuality)).toEqual(10);
+        expect(config.getNumericSettingValue(NumericParameters.MaxQuality)).toEqual(70);
+
+        // The legacy compat settings must stay at their defaults. Mirroring 70 into
+        // CompatQualityMax sends Encoder.MinQP as 15.300000000000004, which the streamer floors to
+        // 15 and converts back by rounding to 70.588 -> 71, so the value it applies drifts one step
+        // looser per connect until it reaches a fixed point unrelated to the configured one.
+        expect(config.getNumericSettingValue(NumericParameters.CompatQualityMin)).toEqual(0);
+        expect(config.getNumericSettingValue(NumericParameters.CompatQualityMax)).toEqual(100);
+    });
+
     it('should send data through the data channel when emitUIInteraction is called', () => {
         mockHTMLMediaElement({ ableToPlay: true, readyState: 2 });
         

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -196,18 +196,23 @@ export class PixelStreaming {
         });
 
         // direct quality factor settings
+        //
+        // These deliberately do not mirror into CompatQualityMin/Max. The streamer applies
+        // Encoder.MinQuality/Encoder.MaxQuality verbatim, so mirroring only adds a lossy round trip
+        // through the legacy QP commands below: quality -> QP is computed in floating point here, and
+        // the streamer parses that string as an integer before converting back by rounding. Flooring
+        // one way and rounding the other is not the identity, so each pass loosened both bounds and
+        // the streamer's configured values drifted further on every connect.
         this.config._addOnNumericSettingChangedListener(NumericParameters.MinQuality, (newValue: number) => {
             Logger.Info('--------  Sending MinQuality  --------');
             this._webRtcController.sendEncoderMinQuality(newValue);
             Logger.Info('-------------------------------------------');
-            this.config.setNumericSetting(NumericParameters.CompatQualityMin, newValue);
         });
 
         this.config._addOnNumericSettingChangedListener(NumericParameters.MaxQuality, (newValue: number) => {
             Logger.Info('--------  Sending MaxQuality  --------');
             this._webRtcController.sendEncoderMaxQuality(newValue);
             Logger.Info('-------------------------------------------');
-            this.config.setNumericSetting(NumericParameters.CompatQualityMax, newValue);
         });
 
         // new quality value that gets scaled to qp for legacy reasons


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [fix(frontend): stop mirroring quality settings into the legacy compat QP settings (#985)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/985)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)