### PR TITLE
fix(frontend): stop futureDefaults force-enabling webpack's built-in TS/HTML support

### DIFF
--- a/Frontend/implementations/react/webpack.common.js
+++ b/Frontend/implementations/react/webpack.common.js
@@ -70,7 +70,14 @@ module.exports = {
       hashFunction: 'xxhash64',
     },
     experiments: {
-      futureDefaults: true
+      futureDefaults: true,
+      // `futureDefaults` force-enables webpack's built-in TypeScript support, which
+      // cannot handle .tsx/JSX and would otherwise claim our .tsx entry points.
+      // ts-loader (configured above) handles .ts/.tsx instead.
+      typescript: false,
+      // Likewise, keep html-loader/html-webpack-plugin in charge of .html templates
+      // rather than the built-in html module type.
+      html: false
     },
 	devServer: {
     	static: {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

(React reference implementation — `Frontend/implementations/react`.)

## Problem statement:

`npm run build` fails at the root with 8 errors from the React implementation. The root cause:

```
ERROR in ./src/index.tsx
Module build failed: Error: experiments.typescript does not support .tsx/JSX.
Use a TSX-capable loader (e.g. swc-loader, esbuild-loader, ts-loader) for .tsx files.
```

webpack 5.110 added built-in TypeScript and HTML module types. Their `"auto"` detection deliberately steps aside when a loader is already registered for those files ([`lib/config/defaults.js`](https://github.com/webpack/webpack/blob/main/lib/config/defaults.js)):

```js
if (experiments.typescript === "auto") {
  experiments.typescript =
    typeof require("module").stripTypeScriptTypes === "function" &&
    !(RuleSetCompiler.hasRuleForResource(rules, "/file.ts") || ...);
}
```

But `experiments.futureDefaults: true` force-enables them unconditionally (`F(experiments, "typescript", () => experiments.futureDefaults ? true : "auto")`), bypassing that opt-out. The built-in TypeScript support can't handle JSX, so it claimed our `.tsx` entry points instead of `ts-loader`.

The remaining 7 errors were downstream fallout from the built-in HTML type being force-enabled the same way: it tried to resolve the Google Fonts `<link>` as a module (`UnhandledSchemeError: Reading from "https://fonts.googleapis.com/css2" is not handled by plugins`) and then collided with `html-webpack-plugin` over `index.html` (`Conflict: Multiple assets emit different content to the same filename index.html`).

`experiments.futureDefaults: true` has been in this config since the original React sample (#159) and was harmless until the webpack bump. The webpack range moved `^5.97.1` → `^5.110.3` in the Dependabot dev-dependency bump, resolving to 5.110.3. This is the same class of webpack 5.110 fallout as #1053.

Only the React implementation sets `futureDefaults`, which is why the TypeScript implementation is unaffected.

## Solution

Opt the two experiments out explicitly so `ts-loader` and `html-loader`/`html-webpack-plugin` stay in charge, while keeping the rest of `futureDefaults` intact:

```js
experiments: {
  futureDefaults: true,
  typescript: false,
  html: false
},
```

One file, 8 lines (6 of them comments explaining why).

## Documentation

No user-facing change — build configuration only.

## Test Plan and Compatibility

- `npm run build` in `Frontend/implementations/react` — passes (was 8 errors).
- `npm run build:dev` in the same workspace — passes, confirming both webpack configs.
- `npm run build` at the repo root — exits 0 across all workspaces.
- Verified emitted artifacts are correct, not merely error-free: `dist/index.html` references the hashed favicon, the copied `images/`, and the `index.js` bundle, with the external Google Fonts URLs left intact as `<link>` tags rather than being resolved as modules.

No runtime or API surface is touched, and the React implementation is `private: true` so no published package is affected.