### PR TITLE
chore(ci): update org references from EpicGamesExt to EpicGames (#901)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,5 @@
 {
-    "repoOwner": "EpicGamesExt",
+    "repoOwner": "EpicGames",
     "repoName": "PixelStreamingInfrastructure",
     "targetBranchChoices": ["master", "UE5.2", "UE5.3", "UE5.4", "UE5.5", "UE5.6"],
     "autoMerge": true,

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   streaming-test-linux:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
@@ -42,7 +42,7 @@ jobs:
         path: Extras/FrontendTests/results
 
   # streaming-test-win:
-  #   if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
   #   runs-on: windows-latest
   #   steps:
   #   - name: Checkout source code
@@ -59,7 +59,7 @@ jobs:
   #   - name: Download streamer
   #     uses: robinraju/release-downloader@v1
   #     with:
-  #       repository: 'EpicGamesExt/PixelStreamingInfrastructure'
+  #       repository: 'EpicGames/PixelStreamingInfrastructure'
   #       tag: 'minimal-streamer'
   #       fileName: 'Minimal-PixelStreamer-5.6.7z'
   #

--- a/.github/workflows/healthcheck-image-sfu.yml
+++ b/.github/workflows/healthcheck-image-sfu.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-image-wilbur.yml
+++ b/.github/workflows/healthcheck-image-wilbur.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-using-local-deps:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   linkChecker:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-script-linux:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -24,7 +24,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-macos:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: macos-latest
     steps:
       - name: Checkout source code
@@ -36,7 +36,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-windows:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: windows-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/healthcheck-signalling-protocol.yml
+++ b/.github/workflows/healthcheck-signalling-protocol.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   signalling-protocol-test:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   # Uncomment when we can Linux test to capture a non-black screenshot using software renderer.
   # streaming-test-linux:
-  #   if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout source code
@@ -46,7 +46,7 @@ jobs:
   #       path: Extras/MinimalStreamTester/results
 
   streaming-test-win:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: windows-latest
     steps:
     - name: Checkout source code
@@ -64,7 +64,7 @@ jobs:
     - name: Download streamer
       uses: robinraju/release-downloader@v1
       with:
-        repository: 'EpicGamesExt/PixelStreamingInfrastructure'
+        repository: 'EpicGames/PixelStreamingInfrastructure'
         tag: 'minimal-streamer-5.6'
         fileName: 'Minimal-PixelStreamer-5.6-Win64-Development.7z'
 

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
+    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

(CI / repo configuration.)

## Problem statement:

**All CI healthchecks have been silently skipping on `UE5.6`.** Every guarded job on this branch carries:

```yaml
if: github.repository == 'EpicGamesExt/PixelStreamingInfrastructure'
```

The repo moved from the `EpicGamesExt` org to `EpicGames`. That rename is covered by a URL/API redirect — which is why `EpicGamesExt` URLs still appear to work — but **not** by a runtime string comparison. `github.repository` evaluates to the current canonical name, so the condition is always false and the job skips.

Because `pull_request` runs the workflow file from the PR's own branch, this affects `UE5.6` only. #901 fixed it on `master`, `UE5.8` and `UE5.7`; **`UE5.6` was missed.** The same commit backported to three branches on 2026-09-10 shows it plainly:

```
skipped   backport/UE5.6/pr-985
success   backport/UE5.7/pr-985
success   backport/UE5.8/pr-985
```

11 jobs are affected — all eight healthchecks (libraries, frontend, streaming, signalling protocol, platform scripts, both docker images, markdown links) plus `create-gh-release`, `publish-container-images` and `publish-sfu-image`.

The failure mode is quiet and asymmetric: `changesets-publish-npm-packages.yml` and `changesets-update-changelogs.yml` were never guarded, so **npm publishing kept working while nothing verified it.** Packages have been publishing from `UE5.6` with no healthcheck having run. This is how a broken root `npm run build` (see #1075) reached the branch unnoticed.

## Solution

Backport the CI portion of #901: swap `EpicGamesExt` → `EpicGames` in the 11 workflow guards, plus

- `.backportrc.json` `repoOwner`, so future backports target the correct org;
- the `robinraju/release-downloader` `repository:` inputs that fetch the test streamer.

Scope is deliberately limited to CI-affecting files. The remaining `EpicGamesExt` strings on this branch (prose docs, auto-generated API docs, historical `CHANGELOG` entries) are covered by the redirect and left alone. The publishable packages' `repository.url` fields already point at `EpicGames`, so npm OIDC trusted publishing is unaffected.

## Documentation

No user-facing change.

## Test Plan and Compatibility

- Diff is exactly 18 insertions / 18 deletions across 12 files — the guard lines, the two `repository:` inputs, and `repoOwner`. No logic, ordering or step changes.
- Matches #901's CI subset file-for-file and line-count-for-line-count.
- All 15 workflow YAML files and `.backportrc.json` re-parse cleanly.
- Guard occurrence counts now match `master` per file.
- Verification is inherent: **the healthchecks running on this PR at all is the proof.** They have been skipping on every other `UE5.6` PR, including #1075.

Note that #1075 will keep showing skipped checks until this lands.

A follow-up on `master` will replace the hardcoded-name guard with a fork check, so this fails safe rather than silently skipping on the next rename. That will supersede these lines when it backports here.