### PR TITLE
ci: add react implementation build to library healthcheck

### DIFF
--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -11,6 +11,7 @@ on:
       - "Frontend/library/**"
       - "Frontend/ui-library/**"
       - "Frontend/implementations/typescript/**"
+      - "Frontend/implementations/react/**"
 
 permissions:
   contents: read
@@ -63,3 +64,7 @@ jobs:
     - name: Build of frontend implementation as ES6
       working-directory: Frontend/implementations/typescript
       run: npm run build:esm
+
+    - name: Build of react frontend implementation
+      working-directory: Frontend/implementations/react
+      run: npm run build


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

(CI coverage for `Frontend/implementations/react`.)

## Problem statement:

**The react implementation has no build coverage in any workflow, on any branch.**

`healthcheck-libraries.yml` enumerates workspaces explicitly and stops at `implementations/typescript`:

```yaml
- name: Build of frontend implementation as ES6
  working-directory: Frontend/implementations/typescript
  run: npm run build:esm
```

`healthcheck-frontend.yml` *does* trigger on `Frontend/**`, so react edits fire it — but its job is a Playwright/docker streaming test, not a build of that workspace. Nothing anywhere runs `npm run build` in `Frontend/implementations/react`.

So a broken react build reaches release branches unnoticed. That is exactly what happened in #1075: webpack 5.110 added built-in TypeScript support, `experiments.futureDefaults: true` force-enabled it, and it claimed the `.tsx` entry points — breaking the root `npm run build` with 8 errors on `UE5.6`, with no check to catch it.

This is not only a `UE5.6` concern. `UE5.7` still carries `experiments.futureDefaults: true` with its webpack range already bumped to `^5.110.3` while its lockfile is pinned at `5.107.2` — it breaks the same way the moment that lock re-resolves. This check is what turns that from a silent release-branch breakage into a red PR.

## Solution

Add the workspace to the trigger paths, and build it after the typescript implementation — the point at which its workspace dependency (`Frontend/library`) has already been built by an earlier step.

```yaml
- name: Build of react frontend implementation
  working-directory: Frontend/implementations/react
  run: npm run build
```

Build only, no lint: the react workspace's `lint` script is intentionally empty (`"lint": ""`).

## Documentation

No user-facing change.

## Test Plan and Compatibility

- Verified the react build is green on `master` before gating CI on it, so this PR does not land a red check: installed from the committed lockfile (resolves webpack `5.107.1`), built `Common` → `Frontend/library` → `Frontend/implementations/react`, exit 0.
- `master` is unaffected by the #1075 breakage — `futureDefaults` was removed here by #931 — so the new step is green on this branch on its own merits, not by coincidence of pinning.
- Workflow YAML re-parses; job goes from 11 to 12 steps.
- Two-line addition plus one path entry. No change to existing steps, ordering, or triggers.

## Backporting

Wants `auto-backport`, but **ordering matters** — the new check fails on branches that still have the underlying bug:

- **`UE5.6`** — land #1075 first, or this check goes red.
- **`UE5.7`** — still has `futureDefaults` with a stale lock. Needs the #1075 equivalent first. Happy to raise that separately; it is currently latent, and this check is what would surface it.
- **`UE5.8`** — unaffected (`futureDefaults` already absent).