### PR TITLE
ci: guard jobs on fork status instead of hardcoded repo name

### DIFF
--- a/.github/workflows/changesets-prune-master.yml
+++ b/.github/workflows/changesets-prune-master.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   prune:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     name: Prune
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   streaming-test-linux:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
@@ -44,7 +44,7 @@ jobs:
         path: Extras/FrontendTests/results
 
   # streaming-test-win:
-  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+  #   if: github.event.repository.fork == false
   #   runs-on: windows-latest
   #   steps:
   #   - name: Checkout source code

--- a/.github/workflows/healthcheck-image-sfu.yml
+++ b/.github/workflows/healthcheck-image-sfu.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-image-wilbur.yml
+++ b/.github/workflows/healthcheck-image-wilbur.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-using-local-deps:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   linkChecker:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-script-linux:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -24,7 +24,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-macos:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: macos-latest
     steps:
       - name: Checkout source code
@@ -36,7 +36,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-windows:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/healthcheck-signalling-protocol.yml
+++ b/.github/workflows/healthcheck-signalling-protocol.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   signalling-protocol-test:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   # Uncomment when we can Linux test to capture a non-black screenshot using software renderer.
   # streaming-test-linux:
-  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+  #   if: github.event.repository.fork == false
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout source code
@@ -46,7 +46,7 @@ jobs:
   #       path: Extras/MinimalStreamTester/results
 
   streaming-test-win:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

(CI configuration.)

## Problem statement:

Every guarded job tests the repository by name:

```yaml
if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
```

This is a runtime string comparison, so it silently breaks whenever the repo or org is renamed — the GitHub URL/API redirect does not cover it. **This has already happened once.** The `EpicGamesExt` → `EpicGames` move disabled *all* CI on `UE5.6` (11 jobs) while the same jobs ran normally on branches that had #901, and it went unnoticed for months. #1076 repairs that branch; this PR removes the class of bug.

The failure mode is the dangerous direction. A stale name makes the guard **false**, so jobs skip silently and PRs show green with nothing having run. Nobody notices an absent check — and on `UE5.6` the unguarded changesets workflows kept publishing to npm the whole time, so packages shipped with no healthcheck behind them.

## Solution

The guard's intent is "don't run on forks", so test that directly:

```yaml
if: github.event.repository.fork == false
```

16 guards across 12 workflows.

**Behaviour-preserving.** For `pull_request`, `github.event.repository` is the *base* repo, so fork PRs into this repo still run, exactly as today; a push to a fork still skips:

| Scenario | `github.repository ==` | `fork == false` |
|---|---|---|
| push / dispatch on this repo | runs | runs |
| PR from a fork into this repo | runs | runs |
| push on a fork | skips | skips |
| after a repo/org rename | **silently skips everything** | runs |

**Fails in the safe direction.** `changesets-prune-master.yml` also triggers on `schedule`. If `github.event.repository` were ever absent from a payload, [GitHub coerces mismatched types to numbers](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions) — `null` → `0` and `false` → `0` — so the comparison is **true** and the job runs rather than silently skipping. The old guard degraded to "skip"; this one degrades to "run".

## Documentation

No user-facing change.

## Test Plan and Compatibility

- All 15 workflow YAML files re-parse; every `if:` expression was read back post-edit and confirmed to be the intended value.
- 16/16 name-based guards replaced; zero `github.repository ==` comparisons remain in `.github/workflows/`.
- Audited the trigger set of every guarded workflow (`push`, `pull_request`, `workflow_dispatch`, `schedule`) to confirm none can silently skip under the new expression.
- Diff is 16 insertions / 16 deletions — guard lines only, including the two commented-out jobs so they stay correct if uncommented. No steps, ordering or triggers touched.
- Self-verifying in the same way as #1076: the healthchecks running on this PR is the evidence the new guard evaluates true.

## Backporting

Wants `auto-backport` to `UE5.8`, `UE5.7` and `UE5.6`. On `UE5.6` this supersedes the lines #1076 repairs, so **land #1076 first** and expect a trivial conflict on those guard lines — take this PR's version.