### PR TITLE
[UE5.8] ci: guard jobs on fork status instead of hardcoded repo name (#1078)

### DIFF
--- a/.github/workflows/changesets-prune-master.yml
+++ b/.github/workflows/changesets-prune-master.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   prune:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     name: Prune
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   streaming-test-linux:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
@@ -42,7 +42,7 @@ jobs:
         path: Extras/FrontendTests/results
 
   # streaming-test-win:
-  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+  #   if: github.event.repository.fork == false
   #   runs-on: windows-latest
   #   steps:
   #   - name: Checkout source code

--- a/.github/workflows/healthcheck-image-sfu.yml
+++ b/.github/workflows/healthcheck-image-sfu.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-image-wilbur.yml
+++ b/.github/workflows/healthcheck-image-wilbur.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-using-local-deps:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   linkChecker:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-script-linux:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -24,7 +24,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-macos:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: macos-latest
     steps:
       - name: Checkout source code
@@ -36,7 +36,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-windows:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/healthcheck-signalling-protocol.yml
+++ b/.github/workflows/healthcheck-signalling-protocol.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   signalling-protocol-test:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   # Uncomment when we can Linux test to capture a non-black screenshot using software renderer.
   # streaming-test-linux:
-  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+  #   if: github.event.repository.fork == false
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout source code
@@ -46,7 +46,7 @@ jobs:
   #       path: Extras/MinimalStreamTester/results
 
   streaming-test-win:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.8`:
 - [ci: guard jobs on fork status instead of hardcoded repo name (#1078)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/1078)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)