### PR TITLE
[UE5.6] ci: guard jobs on fork status instead of hardcoded repo name

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # only run this on the main repo, not forks
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/healthcheck-frontend.yml
+++ b/.github/workflows/healthcheck-frontend.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   streaming-test-linux:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
@@ -42,7 +42,7 @@ jobs:
         path: Extras/FrontendTests/results
 
   # streaming-test-win:
-  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+  #   if: github.event.repository.fork == false
   #   runs-on: windows-latest
   #   steps:
   #   - name: Checkout source code

--- a/.github/workflows/healthcheck-image-sfu.yml
+++ b/.github/workflows/healthcheck-image-sfu.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-image-wilbur.yml
+++ b/.github/workflows/healthcheck-image-wilbur.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-docker-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-using-local-deps:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-markdown-links.yml
+++ b/.github/workflows/healthcheck-markdown-links.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   linkChecker:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/healthcheck-platform-scripts.yml
+++ b/.github/workflows/healthcheck-platform-scripts.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-script-linux:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -24,7 +24,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-macos:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: macos-latest
     steps:
       - name: Checkout source code
@@ -36,7 +36,7 @@ jobs:
           curl --retry 10 --retry-delay 20 --retry-connrefused http://localhost:999/api/status
 
   run-script-windows:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/healthcheck-signalling-protocol.yml
+++ b/.github/workflows/healthcheck-signalling-protocol.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   signalling-protocol-test:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/healthcheck-streaming.yml
+++ b/.github/workflows/healthcheck-streaming.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   # Uncomment when we can Linux test to capture a non-black screenshot using software renderer.
   # streaming-test-linux:
-  #   if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+  #   if: github.event.repository.fork == false
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout source code
@@ -46,7 +46,7 @@ jobs:
   #       path: Extras/MinimalStreamTester/results
 
   streaming-test-win:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
     - name: Checkout source code

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-sfu-image.yml
+++ b/.github/workflows/publish-sfu-image.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   signalling-server-image:
-    if: github.repository == 'EpicGames/PixelStreamingInfrastructure'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

(CI configuration.)

## Problem statement:

Manual backport of #1078 — the automatic backport failed with a merge conflict.

## Solution

Cherry-pick of `45d8b3c3` with one conflict resolved.

**The conflict was a single file, `.github/workflows/changesets-prune-master.yml`** (`modify/delete`). That workflow prunes changesets on `master` and exists only on `master` and `UE5.8`; it is not present on this branch. #1078 updated the guard in it along with the other 11, so the cherry-pick tried to modify a file that does not exist here.

Resolved by dropping that file rather than resurrecting it — a master-only workflow should not land on a release branch. The other **11 files applied cleanly with no conflict**, giving 15 guard lines instead of master's 16.

The backport bot also suggested backporting #952, #913, #905 and #901 first. Those are not prerequisites — they are unrelated drift in the bot's ancestry walk. #901's CI portion is already on this branch. The only real conflict was the file above.

## Documentation

No user-facing change.

## Test Plan and Compatibility

- Cherry-pick reproduced locally against this branch's actual head; the sole conflict was the file described above.
- Result: 11 files changed, 15 insertions / 15 deletions — guard lines only.
- All 15 workflow YAML files re-parse; 13 jobs are fork-guarded; **0** `github.repository ==` comparisons remain.
- Confirmed `changesets-prune-master.yml` was not added to this branch.
- Self-verifying: the healthchecks running on this PR is the evidence the new guard evaluates true.