### PR TITLE
[UE5.8] ci: add react implementation build to library healthcheck (#1077)

### DIFF
--- a/.github/workflows/healthcheck-libraries.yml
+++ b/.github/workflows/healthcheck-libraries.yml
@@ -11,6 +11,7 @@ on:
       - "Frontend/library/**"
       - "Frontend/ui-library/**"
       - "Frontend/implementations/typescript/**"
+      - "Frontend/implementations/react/**"
 
 permissions:
   contents: read
@@ -63,3 +64,7 @@ jobs:
     - name: Build of frontend implementation as ES6
       working-directory: Frontend/implementations/typescript
       run: npm run build:esm
+
+    - name: Build of react frontend implementation
+      working-directory: Frontend/implementations/react
+      run: npm run build


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.8`:
 - [ci: add react implementation build to library healthcheck (#1077)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/1077)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)